### PR TITLE
fix(angular): set `SliderWorkComponent` transformed thumbnails

### DIFF
--- a/packages/angular/src/app/shared/slider/slider-work/slider-work.component.spec.ts
+++ b/packages/angular/src/app/shared/slider/slider-work/slider-work.component.spec.ts
@@ -50,24 +50,22 @@ describe('SliderWorkComponent', () => {
         fixture.detectChanges();
       });
 
-      it('should set `caseStudies`', () => {
+      it('should call `ApiPipe` with `thumbnail`', () => {
+        comp.caseStudies.forEach(caseStudy =>
+          expect(apiPipe).toHaveBeenCalledWith(caseStudy.thumbnail)
+        );
+      });
+
+      it('should set `caseStudies` with transformed `thumbnail`', () => {
         expect(comp.caseStudies).toEqual(Data.Api.getCaseStudies<void>());
       });
 
-      describe('`images`', () => {
-        it('should call `ApiPipe` with `thumbnail`', () => {
-          comp.caseStudies.forEach(caseStudy =>
-            expect(apiPipe).toHaveBeenCalledWith(caseStudy.thumbnail)
-          );
-        });
-
-        it('should be set as transformed `thumbnail` array', () => {
-          expect(comp.images).toEqual([
-            Data.Api.getCaseStudies('Case Study 1').thumbnail,
-            Data.Api.getCaseStudies('Case Study 2').thumbnail,
-            Data.Api.getCaseStudies('Case Study 3').thumbnail
-          ] as any);
-        });
+      it('should set `images` as transformed `thumbnail` array', () => {
+        expect(comp.images).toEqual([
+          Data.Api.getCaseStudies('Case Study 1').thumbnail,
+          Data.Api.getCaseStudies('Case Study 2').thumbnail,
+          Data.Api.getCaseStudies('Case Study 3').thumbnail
+        ] as any);
       });
 
       it('should call `sliderInit`', () => {

--- a/packages/angular/src/app/shared/slider/slider-work/slider-work.component.ts
+++ b/packages/angular/src/app/shared/slider/slider-work/slider-work.component.ts
@@ -23,10 +23,11 @@ export class SliderWorkComponent extends SliderComponent {
   set caseStudies(caseStudies: Api.CaseStudy[]) {
     if (!caseStudies) return;
 
-    this._caseStudies = caseStudies;
-    this.images = caseStudies.map(
-      ({ thumbnail }) => (thumbnail = this.apiPipe.transform(thumbnail))
-    );
+    this._caseStudies = caseStudies.map(caseStudy => ({
+      ...caseStudy,
+      thumbnail: this.apiPipe.transform(caseStudy.thumbnail)
+    }));
+    this.images = caseStudies.map(({ thumbnail }) => thumbnail as any);
 
     this.sliderInit();
   }


### PR DESCRIPTION
`SliderWorkComponent` `caseStudies` were no longer setting `thumbnail` as transformed by `ApiPipe`, due to side effect removed in 6615e14460f7ad06d76f312b4dba7cb13e627ed3