### PR TITLE
ci: remove `shouldRunRelease` check

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -67,34 +67,3 @@ shouldRunDeploy() {
     return 1;
   fi
 }
-
-shouldRunRelease() {
-  isBuildableCommit() {
-    local typeRegex
-    typeRegex="([a-z]+)(\(\w+\))?:"
-
-    if [[ "$1" =~ $typeRegex ]]; then
-      local commitType
-      commitType=${BASH_REMATCH[1]}
-
-      if [[ $commitType =~ (feat|fix|perf|refactor) ]]; then
-        printf "${PASS}Commit type: ${commitType}${RESET}"
-        return 0
-      else
-        printf "${SKIP}Commit type: ${commitType}${RESET}"
-        return 1
-      fi
-    else
-      printf "${FAIL}No commit type found${RESET}"
-      return 1
-    fi
-  }
-
-  if isBuildableCommit "$(eval $COMMIT_MESSAGE)"; then
-    printf "${PASS_BG} Releasing ${RESET}"
-    return 0;
-  else
-    printf "${SKIP_BG} Not releasing ${RESET}"
-    return 1;
-  fi
-}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,18 +1,11 @@
 #!/bin/bash
 set -e
-source ./scripts/helpers.sh
 
-release() {
-  git config --global user.email "44237005+hkfd-ci@users.noreply.github.com"
-  git config --global user.name "Hkfd CI"
+git config --global user.email "44237005+hkfd-ci@users.noreply.github.com"
+git config --global user.name "Hkfd CI"
 
-  git checkout master
-  git reset --hard
+git checkout master
+git reset --hard
 
-  git remote add release https://${GH_ACCESS_TOKEN}@github.com/hkfd/hkfd.git
-  yarn lerna version --yes --git-remote release
-}
-
-if shouldRunRelease; then
-  release
-fi
+git remote add release https://${GH_ACCESS_TOKEN}@github.com/hkfd/hkfd.git
+yarn lerna version --yes --git-remote release


### PR DESCRIPTION
Previously, `shouldRunRelease` would check the commit type, and only run `release` if the type was either feat, fix, perf, or refactor. This check was only run on the latest commit, which works if the pr only includes a single commit or the top commit is within the range. There doesn't seem to be a way to get the commit range on circle, so this commit removes this check and will now run the release stage on every push to master