### PR TITLE
refactor(angular): add `slidesCount` to sliders

### DIFF
--- a/packages/angular/src/app/shared/slider/slider-work/slider-work.component.spec.ts
+++ b/packages/angular/src/app/shared/slider/slider-work/slider-work.component.spec.ts
@@ -66,12 +66,8 @@ describe('SliderWorkComponent', () => {
         expect(comp.caseStudies).toEqual(caseStudies);
       });
 
-      it('should set `images` as transformed `thumbnail` array', () => {
-        expect(comp.images).toEqual([
-          Data.Api.getCaseStudies('Case Study 1').thumbnail,
-          Data.Api.getCaseStudies('Case Study 2').thumbnail,
-          Data.Api.getCaseStudies('Case Study 3').thumbnail
-        ] as any);
+      it('should set `slidesCount` as `caseStudies.length`', () => {
+        expect(comp.slidesCount).toBe(Data.Api.getCaseStudies<void>().length);
       });
 
       it('should call `sliderInit`', () => {

--- a/packages/angular/src/app/shared/slider/slider-work/slider-work.component.ts
+++ b/packages/angular/src/app/shared/slider/slider-work/slider-work.component.ts
@@ -28,7 +28,7 @@ export class SliderWorkComponent extends SliderComponent {
       ...caseStudy,
       thumbnail: this.apiPipe.transform(caseStudy.thumbnail) as any
     }));
-    this.images = caseStudies.map(({ thumbnail }) => thumbnail as any);
+    this.slidesCount = caseStudies.length;
 
     this.sliderInit();
   }

--- a/packages/angular/src/app/shared/slider/slider.component.spec.ts
+++ b/packages/angular/src/app/shared/slider/slider.component.spec.ts
@@ -41,11 +41,44 @@ describe('SliderComponent', () => {
       expect(comp).toBeTruthy();
     });
 
-    it('should set `images`', () => {
-      compHost.images = Data.Generic.getImages();
-      fixture.detectChanges();
+    describe('`images`', () => {
+      describe('Has `images`', () => {
+        beforeEach(() => {
+          compHost.images = Data.Generic.getImages();
+          fixture.detectChanges();
+        });
 
-      expect(comp.images).toEqual(Data.Generic.getImages());
+        it('should be set', () => {
+          expect(comp.images).toEqual(Data.Generic.getImages());
+        });
+
+        it('should set `slidesCount` as `images.length`', () => {
+          expect(comp.slidesCount).toBe(Data.Generic.getImages().length);
+        });
+
+        it('should call `sliderInit`', () => {
+          expect(comp.sliderInit).toHaveBeenCalled();
+        });
+      });
+
+      describe('No `images`', () => {
+        beforeEach(() => {
+          compHost.images = null;
+          fixture.detectChanges();
+        });
+
+        it('should be `undefined`', () => {
+          expect(comp.images).toEqual(undefined);
+        });
+
+        it('should not set `slidesCount`', () => {
+          expect(comp.slidesCount).toBe(undefined);
+        });
+
+        it('should not call `sliderInit`', () => {
+          expect(comp.sliderInit).not.toHaveBeenCalled();
+        });
+      });
     });
 
     it('should set `delay`', () => {
@@ -68,43 +101,6 @@ describe('SliderComponent', () => {
 
       expect(comp.random).toBe(true);
     });
-
-    it('should not call `sliderInit`', () => {
-      expect(comp.sliderInit).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('`ngOnchanges`', () => {
-    beforeEach(async(() => setupTest()));
-    beforeEach(async(() => createComponent()));
-
-    describe('no `images`', () => {
-      beforeEach(() => comp.ngOnChanges({}));
-
-      it('should not call `sliderInit`', () => {
-        expect(comp.sliderInit).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('no `images.currentValue`', () => {
-      beforeEach(() => comp.ngOnChanges({ images: {} as any }));
-
-      it('should not call `sliderInit`', () => {
-        expect(comp.sliderInit).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('`images` and `images.currentValue`', () => {
-      beforeEach(() =>
-        comp.ngOnChanges({
-          images: { currentValue: Data.Generic.getImages() } as any
-        })
-      );
-
-      it('should call `sliderInit`', () => {
-        expect(comp.sliderInit).toHaveBeenCalled();
-      });
-    });
   });
 
   describe('`ngOnDestroy`', () => {
@@ -122,43 +118,55 @@ describe('SliderComponent', () => {
     beforeEach(async(() => setupTest()));
     beforeEach(async(() => createComponent()));
 
-    describe('`random` is `true`', () => {
-      beforeEach(() => {
-        comp.random = true;
-        comp.images = [{}] as any;
-      });
+    describe('No `slidesCount`', () => {
+      beforeEach(() => (comp.slidesCount = undefined));
 
-      it('should set `currentIndex`', () => {
-        comp.currentIndex = undefined as any;
-        comp.sliderInit();
-
-        expect(comp.currentIndex).toBeDefined();
-      });
-
-      it('should set `currentIndex` as number between `0` and `images.length`', () => {
-        comp.currentIndex = undefined as any;
-        comp.sliderInit();
-
-        expect(comp.currentIndex).toBeLessThanOrEqual(1);
-        expect(comp.currentIndex).toBeGreaterThanOrEqual(0);
+      it('should throw error', () => {
+        expect(() => comp.sliderInit()).toThrowError('No `slidesCount`');
       });
     });
 
-    describe('`random` is `false`', () => {
-      beforeEach(() => (comp.random = false));
+    describe('Has `slidesCount`', () => {
+      beforeEach(() => (comp.slidesCount = 1));
 
-      it('should not set `currentIndex`', () => {
-        comp.currentIndex = undefined as any;
+      describe('`random` is `true`', () => {
+        beforeEach(() => {
+          comp.random = true;
+          comp.images = [{}] as any;
+        });
+
+        it('should set `currentIndex`', () => {
+          comp.currentIndex = undefined as any;
+          comp.sliderInit();
+
+          expect(comp.currentIndex).toBeDefined();
+        });
+
+        it('should set `currentIndex` as number between `0` and `slidesCount`', () => {
+          comp.currentIndex = undefined as any;
+          comp.sliderInit();
+
+          expect(comp.currentIndex).toBeLessThanOrEqual(1);
+          expect(comp.currentIndex).toBeGreaterThanOrEqual(0);
+        });
+      });
+
+      describe('`random` is `false`', () => {
+        beforeEach(() => (comp.random = false));
+
+        it('should not set `currentIndex`', () => {
+          comp.currentIndex = undefined as any;
+          comp.sliderInit();
+
+          expect(comp.currentIndex).toBeUndefined();
+        });
+      });
+
+      it('should call `startTimer`', () => {
         comp.sliderInit();
 
-        expect(comp.currentIndex).toBeUndefined();
+        expect(comp.startTimer).toHaveBeenCalled();
       });
-    });
-
-    it('should call `startTimer`', () => {
-      comp.sliderInit();
-
-      expect(comp.startTimer).toHaveBeenCalled();
     });
   });
 
@@ -326,56 +334,68 @@ describe('SliderComponent', () => {
       comp.images = Data.Generic.getImages();
     });
 
-    it('should set `currentIndex` as `currentIndex` add `offset` if positive `offset` arg', () => {
-      comp.currentIndex = 0;
-      comp.changeImage(2);
+    describe('No `slidesCount`', () => {
+      beforeEach(() => (comp.slidesCount = undefined));
 
-      expect(comp.currentIndex).toBe(2);
-    });
-
-    it('should set `currentIndex` as `currentIndex` subtract `offset` if negative `offset` arg', () => {
-      comp.currentIndex = 2;
-      comp.changeImage(-2);
-
-      expect(comp.currentIndex).toBe(0);
-    });
-
-    it('should increment `currentIndex` if no arg', () => {
-      comp.currentIndex = 0;
-      comp.changeImage();
-
-      expect(comp.currentIndex).toBe(1);
-    });
-
-    describe('`currentIndex` is `0`', () => {
-      it('should set `currentIndex` as last `images` if `-1` arg', () => {
-        comp.currentIndex = 0;
-        comp.changeImage(-1);
-
-        expect(comp.currentIndex).toBe(Data.Generic.getImages().length - 1);
-      });
-
-      it('should set `currentIndex` as `1` if `1` arg', () => {
-        comp.currentIndex = 0;
-        comp.changeImage(1);
-
-        expect(comp.currentIndex).toBe(1);
+      it('should throw error', () => {
+        expect(() => comp.changeImage()).toThrowError('No `slidesCount`');
       });
     });
 
-    describe('`currentIndex` is last `images`', () => {
-      it('should set `currentIndex` as `0` if `1` arg', () => {
-        comp.currentIndex = Data.Generic.getImages().length - 1;
-        comp.changeImage(1);
+    describe('Has `slidesCount`', () => {
+      beforeEach(() => (comp.slidesCount = Data.Generic.getImages().length));
+
+      it('should set `currentIndex` as `currentIndex` add `offset` if positive `offset` arg', () => {
+        comp.currentIndex = 0;
+        comp.changeImage(2);
+
+        expect(comp.currentIndex).toBe(2);
+      });
+
+      it('should set `currentIndex` as `currentIndex` subtract `offset` if negative `offset` arg', () => {
+        comp.currentIndex = 2;
+        comp.changeImage(-2);
 
         expect(comp.currentIndex).toBe(0);
       });
 
-      it('should set `currentIndex` as second to last `images` if `-1` arg', () => {
-        comp.currentIndex = Data.Generic.getImages().length - 1;
-        comp.changeImage(-1);
+      it('should increment `currentIndex` if no arg', () => {
+        comp.currentIndex = 0;
+        comp.changeImage();
 
-        expect(comp.currentIndex).toBe(Data.Generic.getImages().length - 2);
+        expect(comp.currentIndex).toBe(1);
+      });
+
+      describe('`currentIndex` is `0`', () => {
+        it('should set `currentIndex` as last `images` if `-1` arg', () => {
+          comp.currentIndex = 0;
+          comp.changeImage(-1);
+
+          expect(comp.currentIndex).toBe(Data.Generic.getImages().length - 1);
+        });
+
+        it('should set `currentIndex` as `1` if `1` arg', () => {
+          comp.currentIndex = 0;
+          comp.changeImage(1);
+
+          expect(comp.currentIndex).toBe(1);
+        });
+      });
+
+      describe('`currentIndex` is last `images`', () => {
+        it('should set `currentIndex` as `0` if `1` arg', () => {
+          comp.currentIndex = Data.Generic.getImages().length - 1;
+          comp.changeImage(1);
+
+          expect(comp.currentIndex).toBe(0);
+        });
+
+        it('should set `currentIndex` as second to last `images` if `-1` arg', () => {
+          comp.currentIndex = Data.Generic.getImages().length - 1;
+          comp.changeImage(-1);
+
+          expect(comp.currentIndex).toBe(Data.Generic.getImages().length - 2);
+        });
       });
     });
   });

--- a/packages/angular/src/app/shared/slider/slider.component.ts
+++ b/packages/angular/src/app/shared/slider/slider.component.ts
@@ -1,8 +1,6 @@
 import {
   Component,
-  OnChanges,
   OnDestroy,
-  SimpleChanges,
   Input,
   HostListener,
   NgZone,
@@ -18,8 +16,10 @@ import { Image } from 'generic';
   templateUrl: './slider.component.html',
   styleUrls: ['./slider.component.scss']
 })
-export class SliderComponent implements OnChanges, OnDestroy {
+export class SliderComponent implements OnDestroy {
   private timer: number | undefined;
+  private _images!: Image[];
+  slidesCount: number | undefined;
   currentIndex = 0;
 
   @Input()
@@ -29,7 +29,16 @@ export class SliderComponent implements OnChanges, OnDestroy {
   @Input()
   delay = 2000;
   @Input()
-  images!: Image[];
+  set images(images: Image[] | undefined) {
+    if (!images) return;
+
+    this._images = images;
+    this.slidesCount = images.length;
+    this.sliderInit();
+  }
+  get images(): Image[] | undefined {
+    return this._images;
+  }
 
   @HostListener('mouseenter')
   mouseEnter() {
@@ -46,10 +55,12 @@ export class SliderComponent implements OnChanges, OnDestroy {
   ) {}
 
   changeImage(offset = 1) {
+    if (!this.slidesCount) throw new Error('No `slidesCount`');
+
     const index = this.currentIndex + offset;
 
-    if (index < 0) return (this.currentIndex = this.images.length - 1);
-    if (index >= this.images.length) return (this.currentIndex = 0);
+    if (index < 0) return (this.currentIndex = this.slidesCount - 1);
+    if (index >= this.slidesCount) return (this.currentIndex = 0);
 
     return (this.currentIndex = index);
   }
@@ -82,15 +93,13 @@ export class SliderComponent implements OnChanges, OnDestroy {
   }
 
   sliderInit() {
+    if (!this.slidesCount) throw new Error('No `slidesCount`');
+
     const randomInt = (min: number, max: number) =>
       Math.floor(Math.random() * (max - min) + min);
 
-    if (this.random) this.currentIndex = randomInt(0, this.images.length);
+    if (this.random) this.currentIndex = randomInt(0, this.slidesCount);
     this.startTimer();
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes.images && changes.images.currentValue) this.sliderInit();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Previously, `SliderComponent` would use the length of `images` to do work. This meant that `SliderWorkComponent` (that uses its own `caseStudies` instead of `images`), would have to set `images` for `SliderComponent` to figure out the number of slides. This commit removes that unnecessary binding and creates a `slidesCount` variable instead