### PR TITLE
refactor(angular): only show slider nav when slider has content

### DIFF
--- a/packages/angular/src/app/shared/slider/slider-work/slider-work.component.html
+++ b/packages/angular/src/app/shared/slider/slider-work/slider-work.component.html
@@ -1,55 +1,56 @@
-<div class="slider-nav">
-  <button
-    class="slider-prev"
-    type="button"
-    (click)="changeImage(-1)"
-    aria-label="Previous"
-  >
-    <span class="arrow left"></span>
-  </button>
-  <button
-    class="slider-next"
-    type="button"
-    (click)="changeImage(1)"
-    aria-label="Next"
-  >
-    <span class="arrow right"></span>
-  </button>
-</div>
-
-<div
-  class="slide-container"
-  *ngIf="caseStudies"
-  [style.transform]="'translateX(' + this.currentIndex * -100 + '%)'"
->
-  <div
-    class="slide {{ caseStudy?.colour }}"
-    *ngFor="let caseStudy of caseStudies"
-  >
-    <div class="slide-info">
-      <div class="info-meta">
-        <a
-          [routerLink]="['/work', caseStudy?.id]"
-          [attr.aria-label]="caseStudy?.title"
-        >
-          {{ caseStudy?.title }}
-        </a>
-        <span>{{ caseStudy?.sector }}</span>
-      </div>
-
-      <div class="info-more">
-        <a
-          class="button"
-          [routerLink]="['/work', caseStudy?.id]"
-          [attr.aria-label]="'Read More'"
-        >
-          SEE THE CASE STUDY
-        </a>
-      </div>
-    </div>
-    <image-component
-      [image]="caseStudy?.thumbnail"
-      full-height
-    ></image-component>
+<ng-container *ngIf="caseStudies">
+  <div class="slider-nav">
+    <button
+      class="slider-prev"
+      type="button"
+      (click)="changeImage(-1)"
+      aria-label="Previous"
+    >
+      <span class="arrow left"></span>
+    </button>
+    <button
+      class="slider-next"
+      type="button"
+      (click)="changeImage(1)"
+      aria-label="Next"
+    >
+      <span class="arrow right"></span>
+    </button>
   </div>
-</div>
+
+  <div
+    class="slide-container"
+    [style.transform]="'translateX(' + this.currentIndex * -100 + '%)'"
+  >
+    <div
+      class="slide {{ caseStudy?.colour }}"
+      *ngFor="let caseStudy of caseStudies"
+    >
+      <div class="slide-info">
+        <div class="info-meta">
+          <a
+            [routerLink]="['/work', caseStudy?.id]"
+            [attr.aria-label]="caseStudy?.title"
+          >
+            {{ caseStudy?.title }}
+          </a>
+          <span>{{ caseStudy?.sector }}</span>
+        </div>
+
+        <div class="info-more">
+          <a
+            class="button"
+            [routerLink]="['/work', caseStudy?.id]"
+            [attr.aria-label]="'Read More'"
+          >
+            SEE THE CASE STUDY
+          </a>
+        </div>
+      </div>
+      <image-component
+        [image]="caseStudy?.thumbnail"
+        full-height
+      ></image-component>
+    </div>
+  </div>
+</ng-container>

--- a/packages/angular/src/app/shared/slider/slider-work/slider-work.component.spec.ts
+++ b/packages/angular/src/app/shared/slider/slider-work/slider-work.component.spec.ts
@@ -103,57 +103,53 @@ describe('SliderWorkComponent', () => {
   });
 
   describe('Template', () => {
-    beforeEach(() => {
-      compHost.caseStudies = Data.Api.getCaseStudies<void>();
-      changeDetectorRef.markForCheck();
-      fixture.detectChanges();
-    });
-
-    describe('Nav', () => {
-      describe('Prev', () => {
-        it('should be displayed', () => {
-          expect(page.sliderPrev).toBeTruthy();
-        });
-
-        it('should call `changeImage` on click with `-1` arg', () => {
-          page.sliderPrev.click();
-
-          expect(comp.changeImage).toHaveBeenCalledWith(-1);
-        });
+    describe('No `caseStudies`', () => {
+      beforeEach(() => {
+        (comp as any)._caseStudies = undefined;
+        changeDetectorRef.markForCheck();
+        fixture.detectChanges();
       });
 
-      describe('Next', () => {
-        it('should be displayed', () => {
-          expect(page.sliderNext).toBeTruthy();
-        });
-
-        it('should call `changeImage` on click with `1` arg', () => {
-          page.sliderNext.click();
-
-          expect(comp.changeImage).toHaveBeenCalledWith(1);
-        });
+      it('should not be displayed', () => {
+        expect(page.sliderPrev).toBeFalsy();
+        expect(page.sliderNext).toBeFalsy();
+        expect(page.slideContainer).toBeFalsy();
       });
     });
 
-    describe('Container', () => {
-      describe('No `caseStudies`', () => {
-        beforeEach(() => {
-          (comp as any)._caseStudies = undefined;
-          changeDetectorRef.markForCheck();
-          fixture.detectChanges();
+    describe('Has `caseStudies`', () => {
+      beforeEach(() => {
+        compHost.caseStudies = Data.Api.getCaseStudies<void>();
+        fixture.detectChanges();
+      });
+
+      describe('Nav', () => {
+        describe('Prev', () => {
+          it('should be displayed', () => {
+            expect(page.sliderPrev).toBeTruthy();
+          });
+
+          it('should call `changeImage` on click with `-1` arg', () => {
+            page.sliderPrev.click();
+
+            expect(comp.changeImage).toHaveBeenCalledWith(-1);
+          });
         });
 
-        it('should not be displayed', () => {
-          expect(page.slideContainer).toBeFalsy();
+        describe('Next', () => {
+          it('should be displayed', () => {
+            expect(page.sliderNext).toBeTruthy();
+          });
+
+          it('should call `changeImage` on click with `1` arg', () => {
+            page.sliderNext.click();
+
+            expect(comp.changeImage).toHaveBeenCalledWith(1);
+          });
         });
       });
 
-      describe('Has `caseStudies`', () => {
-        beforeEach(() => {
-          compHost.caseStudies = Data.Api.getCaseStudies<void>();
-          fixture.detectChanges();
-        });
-
+      describe('Container', () => {
         it('should be displayed', () => {
           expect(page.slideContainer).toBeTruthy();
         });

--- a/packages/angular/src/app/shared/slider/slider.component.html
+++ b/packages/angular/src/app/shared/slider/slider.component.html
@@ -1,30 +1,31 @@
-<div class="slider-nav">
-  <button
-    class="slider-prev"
-    type="button"
-    (click)="changeImage(-1)"
-    aria-label="Previous"
-  >
-    <span class="arrow left"></span>
-  </button>
-  <button
-    class="slider-next"
-    type="button"
-    (click)="changeImage(1)"
-    aria-label="Next"
-  >
-    <span class="arrow right"></span>
-  </button>
-</div>
-
-<ng-content></ng-content>
-
-<div
-  class="slide-container"
-  *ngIf="images"
-  [style.transform]="'translateX(' + this.currentIndex * -100 + '%)'"
->
-  <div class="slide" *ngFor="let image of images">
-    <image-component [image]="image" full-height></image-component>
+<ng-container *ngIf="images">
+  <div class="slider-nav">
+    <button
+      class="slider-prev"
+      type="button"
+      (click)="changeImage(-1)"
+      aria-label="Previous"
+    >
+      <span class="arrow left"></span>
+    </button>
+    <button
+      class="slider-next"
+      type="button"
+      (click)="changeImage(1)"
+      aria-label="Next"
+    >
+      <span class="arrow right"></span>
+    </button>
   </div>
-</div>
+
+  <ng-content></ng-content>
+
+  <div
+    class="slide-container"
+    [style.transform]="'translateX(' + this.currentIndex * -100 + '%)'"
+  >
+    <div class="slide" *ngFor="let image of images">
+      <image-component [image]="image" full-height></image-component>
+    </div>
+  </div>
+</ng-container>

--- a/packages/angular/src/app/shared/slider/slider.component.spec.ts
+++ b/packages/angular/src/app/shared/slider/slider.component.spec.ts
@@ -485,62 +485,60 @@ describe('SliderComponent', () => {
   describe('Template', () => {
     beforeEach(async(() => setupTest()));
     beforeEach(async(() => createComponent()));
-    beforeEach(() => {
-      compHost.images = Data.Generic.getImages();
-      fixture.detectChanges();
+
+    describe('No `images`', () => {
+      beforeEach(() => {
+        (comp as any)._images = undefined;
+        changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+      });
+
+      it('should not be displayed', () => {
+        expect(page.sliderPrev).toBeFalsy();
+        expect(page.sliderNext).toBeFalsy();
+        expect(page.slideContainer).toBeFalsy();
+      });
     });
 
-    describe('Nav', () => {
-      describe('Prev', () => {
+    describe('Has `images`', () => {
+      beforeEach(() => {
+        compHost.images = Data.Generic.getImages();
+        fixture.detectChanges();
+      });
+
+      describe('Nav', () => {
+        describe('Prev', () => {
+          it('should be displayed', () => {
+            expect(page.sliderPrev).toBeTruthy();
+          });
+
+          it('should call `changeImage` on click with `-1` arg', () => {
+            page.sliderPrev.click();
+
+            expect(comp.changeImage).toHaveBeenCalledWith(-1);
+          });
+        });
+
+        describe('Next', () => {
+          it('should be displayed', () => {
+            expect(page.sliderNext).toBeTruthy();
+          });
+
+          it('should call `changeImage` on click with `1` arg', () => {
+            page.sliderNext.click();
+
+            expect(comp.changeImage).toHaveBeenCalledWith(1);
+          });
+        });
+      });
+
+      describe('Projected content', () => {
         it('should be displayed', () => {
-          expect(page.sliderPrev).toBeTruthy();
-        });
-
-        it('should call `changeImage` on click with `-1` arg', () => {
-          page.sliderPrev.click();
-
-          expect(comp.changeImage).toHaveBeenCalledWith(-1);
+          expect(page.projectedContent.textContent).toBe('Content');
         });
       });
 
-      describe('Next', () => {
-        it('should be displayed', () => {
-          expect(page.sliderNext).toBeTruthy();
-        });
-
-        it('should call `changeImage` on click with `1` arg', () => {
-          page.sliderNext.click();
-
-          expect(comp.changeImage).toHaveBeenCalledWith(1);
-        });
-      });
-    });
-
-    describe('Projected content', () => {
-      it('should be displayed', () => {
-        expect(page.projectedContent.textContent).toBe('Content');
-      });
-    });
-
-    describe('Container', () => {
-      describe('No `images`', () => {
-        beforeEach(() => {
-          (comp as any)._images = undefined;
-          changeDetectorRef.markForCheck();
-          fixture.detectChanges();
-        });
-
-        it('should not be displayed', () => {
-          expect(page.slideContainer).toBeFalsy();
-        });
-      });
-
-      describe('Has `images`', () => {
-        beforeEach(() => {
-          compHost.images = Data.Generic.getImages();
-          fixture.detectChanges();
-        });
-
+      describe('Container', () => {
         it('should be displayed', () => {
           expect(page.slideContainer).toBeTruthy();
         });


### PR DESCRIPTION
Previously, the slider would always show the nav, even if the slider had no content to display. This meant that if there was no content, or an error happened, the user would be able to trigger the navigation