### PR TITLE
perf(angular): use prismic text pipe instead of component binding

### DIFF
--- a/packages/angular/src/app/pages/careers/career/career.component.html
+++ b/packages/angular/src/app/pages/careers/career/career.component.html
@@ -4,7 +4,7 @@
   <section id="intro">
     <div id="intro-info">
       <h1 *ngIf="career?.data?.title">
-        {{ richText.asText(career?.data?.title) }}
+        {{ career?.data?.title | prismicText: 'asText' }}
       </h1>
     </div>
   </section>

--- a/packages/angular/src/app/pages/careers/career/career.component.spec.ts
+++ b/packages/angular/src/app/pages/careers/career/career.component.spec.ts
@@ -9,11 +9,11 @@ import {
   MockPrismicService,
   StubPrismicTextBlockComponent,
   StubErrorComponent,
+  MockPrismicTextPipe,
   Data
 } from 'testing';
 
 import { of } from 'rxjs';
-import { RichText } from 'prismic-dom';
 
 import { PrismicService } from 'shared';
 import { CareerPost } from 'prismic';
@@ -25,8 +25,6 @@ let page: Page;
 let activatedRoute: ActivatedRouteStub;
 let changeDetectorRef: ChangeDetectorRef;
 let prismicService: PrismicService;
-
-jest.spyOn(RichText, 'asText');
 
 beforeEach(jest.clearAllMocks);
 
@@ -40,7 +38,8 @@ describe('CareerComponent', () => {
       declarations: [
         CareerComponent,
         StubPrismicTextBlockComponent,
-        StubErrorComponent
+        StubErrorComponent,
+        MockPrismicTextPipe
       ],
       providers: [
         { provide: ActivatedRoute, useValue: activatedRoute },
@@ -157,14 +156,17 @@ describe('CareerComponent', () => {
             fixture.detectChanges();
           });
 
-          it('should call `RichText` `asText` with `career.data.title` arg', () => {
-            expect(RichText.asText).toHaveBeenCalledWith([
-              { spans: [], text: 'Title', type: 'h1' }
-            ]);
+          it('should be displayed', () => {
+            expect(page.title.textContent).toBeTruthy();
           });
 
-          it('should display title', () => {
-            expect((page.title.textContent as string).trim()).toBe('Title');
+          it('should call `PrismicTextPipe` with `career.data.title` arg', () => {
+            expect(
+              MockPrismicTextPipe.prototype.transform
+            ).toHaveBeenCalledWith(
+              [{ spans: [], text: 'Title', type: 'h1' }],
+              'asText'
+            );
           });
         });
 
@@ -253,6 +255,7 @@ function createComponent() {
   );
   page = new Page();
 
+  jest.spyOn(MockPrismicTextPipe.prototype, 'transform');
   jest.spyOn(changeDetectorRef, 'markForCheck');
   fixture.detectChanges();
   return fixture.whenStable().then(_ => fixture.detectChanges());

--- a/packages/angular/src/app/pages/careers/career/career.component.ts
+++ b/packages/angular/src/app/pages/careers/career/career.component.ts
@@ -9,7 +9,6 @@ import { ActivatedRoute, ParamMap } from '@angular/router';
 
 import { Subscription } from 'rxjs';
 import { switchMap, map, filter } from 'rxjs/operators';
-import { RichText } from 'prismic-dom';
 
 import { PrismicService } from 'shared';
 import { CareerPost } from 'prismic';
@@ -23,8 +22,6 @@ import { CareerPost } from 'prismic';
 export class CareerComponent implements OnInit, OnDestroy {
   careerSub: Subscription | undefined;
   career: CareerPost | null | undefined;
-
-  richText = RichText;
 
   constructor(
     private route: ActivatedRoute,

--- a/packages/angular/src/app/pages/careers/careers.component.html
+++ b/packages/angular/src/app/pages/careers/careers.component.html
@@ -48,10 +48,10 @@
     class="career"
     *ngFor="let career of (careers$ | async)?.results; trackBy: careerTrackBy"
     [routerLink]="['/careers/', career?.uid]"
-    [attr.aria-label]="richText.asText(career?.data?.title)"
+    [attr.aria-label]="career?.data?.title | prismicText: 'asText'"
   >
     <div class="career-info">
-      <h3>{{ richText.asText(career?.data?.title) }}</h3>
+      <h3>{{ career?.data?.title | prismicText: 'asText' }}</h3>
       <span>{{ career?.data?.salary }}</span>
     </div>
   </a>

--- a/packages/angular/src/app/pages/careers/careers.component.spec.ts
+++ b/packages/angular/src/app/pages/careers/careers.component.spec.ts
@@ -3,7 +3,6 @@ import { By } from '@angular/platform-browser';
 import { ChangeDetectionStrategy } from '@angular/core';
 
 import { of } from 'rxjs';
-import { RichText } from 'prismic-dom';
 
 import {
   RouterTestingModule,
@@ -11,7 +10,8 @@ import {
   MockPrismicService,
   MockApiPipe,
   StubImageComponent,
-  Data
+  Data,
+  MockPrismicTextPipe
 } from 'testing';
 
 import { MetaService, PrismicService } from 'shared';
@@ -25,15 +25,18 @@ let page: Page;
 let metaService: MetaService;
 let prismicService: PrismicService;
 
-jest.spyOn(RichText, 'asText');
-
 beforeEach(jest.clearAllMocks);
 
 describe('CareersComponent', () => {
   beforeEach(async(() =>
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
-      declarations: [CareersComponent, StubImageComponent, MockApiPipe],
+      declarations: [
+        CareersComponent,
+        StubImageComponent,
+        MockApiPipe,
+        MockPrismicTextPipe
+      ],
       providers: [
         { provide: MetaService, useClass: MockMetaService },
         { provide: PrismicService, useClass: MockPrismicService }
@@ -139,14 +142,17 @@ describe('CareersComponent', () => {
         });
 
         describe('Career', () => {
-          it('should call `RichText` `asText` with `career.data.title`', () => {
-            expect(RichText.asText).toHaveBeenCalledWith(
-              Data.Prismic.getCareerPosts('post-1').data.title
+          it('should call `PrismicTextPipe` with `career.data.title`', () => {
+            expect(
+              MockPrismicTextPipe.prototype.transform
+            ).toHaveBeenCalledWith(
+              Data.Prismic.getCareerPosts('post-1').data.title,
+              'asText'
             );
           });
 
           it('should display title', () => {
-            expect(page.careerTitle.textContent).toBe('Post 1');
+            expect(page.careerTitle.textContent).toBeTruthy();
           });
 
           it('should display salary', () => {
@@ -210,6 +216,7 @@ function createComponent() {
     PrismicService
   );
   jest.spyOn(MockApiPipe.prototype, 'transform');
+  jest.spyOn(MockPrismicTextPipe.prototype, 'transform');
 
   fixture.detectChanges();
   return fixture.whenStable().then(_ => fixture.detectChanges());

--- a/packages/angular/src/app/pages/careers/careers.component.ts
+++ b/packages/angular/src/app/pages/careers/careers.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
 import { Observable } from 'rxjs';
-import { RichText } from 'prismic-dom';
 
 import { MetaService, PrismicService } from 'shared';
 import { PostsResponse, CareerPost } from 'prismic';
@@ -15,7 +14,6 @@ import { CareersImages } from './careers.images';
 })
 export class CareersComponent implements OnInit {
   careers$: Observable<PostsResponse<CareerPost>> | undefined;
-  richText = RichText;
   images = CareersImages;
 
   constructor(

--- a/packages/angular/src/app/pages/news/news-post/news-post.component.html
+++ b/packages/angular/src/app/pages/news/news-post/news-post.component.html
@@ -7,7 +7,7 @@
         {{ post?.first_publication_date | date: 'dd LLLL' }}
       </span>
       <h1 *ngIf="post?.data?.title">
-        {{ richText.asText(post?.data?.title) }}
+        {{ post?.data?.title | prismicText: 'asText' }}
       </h1>
     </div>
     <image-component

--- a/packages/angular/src/app/pages/news/news-post/news-post.component.spec.ts
+++ b/packages/angular/src/app/pages/news/news-post/news-post.component.spec.ts
@@ -15,10 +15,10 @@ import {
   StubVideoBlockComponent,
   StubImageComponent,
   StubErrorComponent,
-  Data
+  Data,
+  MockPrismicTextPipe
 } from 'testing';
 import { of } from 'rxjs';
-import { RichText } from 'prismic-dom';
 
 import { PrismicService } from 'shared';
 import { NewsPostComponent } from './news-post.component';
@@ -48,7 +48,8 @@ describe('NewsPostComponent', () => {
         StubGalleryBlockComponent,
         StubVideoBlockComponent,
         StubImageComponent,
-        StubErrorComponent
+        StubErrorComponent,
+        MockPrismicTextPipe
       ],
       providers: [
         { provide: ActivatedRoute, useValue: activatedRoute },
@@ -171,12 +172,15 @@ describe('NewsPostComponent', () => {
             });
 
             it('should be displayed', () => {
-              expect(page.title.innerHTML.trim()).toBe('Post 1');
+              expect(page.title.innerHTML).toBeTruthy();
             });
 
-            it('should call `RichText` `asText` with `title`', () => {
-              expect(RichText.asText).toHaveBeenCalledWith(
-                Data.Prismic.getNewsPost().data.title
+            it('should call `PrismicTextPipe` with `title`', () => {
+              expect(
+                MockPrismicTextPipe.prototype.transform
+              ).toHaveBeenCalledWith(
+                Data.Prismic.getNewsPost().data.title,
+                'asText'
               );
             });
           });
@@ -501,7 +505,7 @@ function createComponent() {
   );
   jest.spyOn(changeDetectorRef, 'markForCheck');
   jest.spyOn(MockPrismicPipe.prototype, 'transform');
-  jest.spyOn(RichText, 'asText');
+  jest.spyOn(MockPrismicTextPipe.prototype, 'transform');
   page = new Page();
 
   fixture.detectChanges();

--- a/packages/angular/src/app/pages/news/news-post/news-post.component.ts
+++ b/packages/angular/src/app/pages/news/news-post/news-post.component.ts
@@ -9,7 +9,6 @@ import { ActivatedRoute, ParamMap } from '@angular/router';
 
 import { Subscription } from 'rxjs';
 import { switchMap, map, filter } from 'rxjs/operators';
-import { RichText } from 'prismic-dom';
 
 import { PrismicService } from 'shared';
 import { NewsPost } from 'prismic';
@@ -21,8 +20,6 @@ import { NewsPost } from 'prismic';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NewsPostComponent implements OnInit, OnDestroy {
-  richText = RichText;
-
   postSub: Subscription | undefined;
   post: NewsPost | null | undefined;
 

--- a/packages/angular/src/app/pages/news/news.component.html
+++ b/packages/angular/src/app/pages/news/news.component.html
@@ -16,7 +16,7 @@
       class="post"
       *ngFor="let post of posts?.results; trackBy: postTrackBy"
       [routerLink]="['/news/', post?.uid]"
-      [attr.aria-label]="richText.asText(post?.data?.title)"
+      [attr.aria-label]="post?.data?.title | prismicText: 'asText'"
     >
       <image-component
         *ngIf="post?.data?.image?.proxy?.url"
@@ -27,7 +27,7 @@
         <span class="post-date">
           {{ post?.first_publication_date | date: 'dd/MM' }}
         </span>
-        <h2>{{ richText.asText(post?.data?.title) }}</h2>
+        <h2>{{ post?.data?.title | prismicText: 'asText' }}</h2>
       </div>
       <span class="post-more button">READ MORE</span>
     </a>

--- a/packages/angular/src/app/pages/news/news.component.spec.ts
+++ b/packages/angular/src/app/pages/news/news.component.spec.ts
@@ -11,10 +11,10 @@ import {
   StubImageComponent,
   Data,
   ActivatedRoute,
-  ActivatedRouteStub
+  ActivatedRouteStub,
+  MockPrismicTextPipe
 } from 'testing';
 import { of } from 'rxjs';
-import { RichText } from 'prismic-dom';
 
 import { MetaService, PrismicService } from 'shared';
 import { PostsResponse, NewsPost } from 'prismic';
@@ -56,7 +56,8 @@ describe('NewsComponent', () => {
         TestHostComponent,
         NewsComponent,
         StubImageComponent,
-        MockPrismicPipe
+        MockPrismicPipe,
+        MockPrismicTextPipe
       ],
       providers: [
         { provide: ActivatedRoute, useValue: activatedRoute },
@@ -280,12 +281,15 @@ describe('NewsComponent', () => {
             });
 
             it('should display title', () => {
-              expect(page.postTitle.innerHTML).toBe('Post 1');
+              expect(page.postTitle.innerHTML).toBeTruthy();
             });
 
-            it('should call RichText `asText` with `title`', () => {
-              expect(RichText.asText).toHaveBeenCalledWith(
-                Data.Prismic.getNewsPosts('post-1').data.title
+            it('should call `PrismicTextPipe` with `title`', () => {
+              expect(
+                MockPrismicTextPipe.prototype.transform
+              ).toHaveBeenCalledWith(
+                Data.Prismic.getNewsPosts('post-1').data.title,
+                'asText'
               );
             });
           });
@@ -399,7 +403,7 @@ function createComponent() {
     PrismicService
   );
   jest.spyOn(MockPrismicPipe.prototype, 'transform');
-  jest.spyOn(RichText, 'asText');
+  jest.spyOn(MockPrismicTextPipe.prototype, 'transform');
   page = new Page();
 
   fixture.detectChanges();

--- a/packages/angular/src/app/pages/news/news.component.ts
+++ b/packages/angular/src/app/pages/news/news.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute, ParamMap } from '@angular/router';
 
 import { Observable } from 'rxjs';
 import { switchMap, map } from 'rxjs/operators';
-import { RichText } from 'prismic-dom';
 
 import { MetaService, PrismicService } from 'shared';
 import { PostsResponse, NewsPost } from 'prismic';
@@ -18,7 +17,6 @@ import { NewsAnimations } from './news.animations';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NewsComponent implements OnInit {
-  richText = RichText;
   getPaginationUrl = getPaginationUrl;
 
   posts$: Observable<PostsResponse<NewsPost>> | undefined;

--- a/packages/angular/src/app/shared/blocks/prismic-text-block/prismic-text-block.component.html
+++ b/packages/angular/src/app/shared/blocks/prismic-text-block/prismic-text-block.component.html
@@ -1,1 +1,1 @@
-<div *ngIf="data" [innerHTML]="richText.asHtml(data, linkResolver)"></div>
+<div *ngIf="data" [innerHTML]="data | prismicText: 'asHtml'"></div>

--- a/packages/angular/src/app/shared/blocks/prismic-text-block/prismic-text-block.component.spec.ts
+++ b/packages/angular/src/app/shared/blocks/prismic-text-block/prismic-text-block.component.spec.ts
@@ -1,8 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { Component } from '@angular/core';
-import { Data } from 'testing';
-
-import { RichText } from 'prismic-dom';
+import { Data, MockPrismicTextPipe } from 'testing';
 
 import { PrismicTextBlockComponent } from './prismic-text-block.component';
 import { By } from '@angular/platform-browser';
@@ -23,7 +21,11 @@ export class TestHostComponent {
 describe('TextBlockComponent', () => {
   beforeEach(async(() =>
     TestBed.configureTestingModule({
-      declarations: [TestHostComponent, PrismicTextBlockComponent]
+      declarations: [
+        TestHostComponent,
+        PrismicTextBlockComponent,
+        MockPrismicTextPipe
+      ]
     }).compileComponents()));
 
   beforeEach(async(() => createComponent()));
@@ -41,32 +43,6 @@ describe('TextBlockComponent', () => {
     expect(comp.data).toEqual(Data.Prismic.getText());
   });
 
-  describe('`linkResolver`', () => {
-    it('should return `/news/$uid` if `type` arg is `news`', () => {
-      const res = comp.linkResolver({
-        type: 'news',
-        uid: 'post'
-      } as any);
-
-      expect(res).toBe('/news/post');
-    });
-
-    it('should return `/careers/$uid` if `type` arg is `career`', () => {
-      const res = comp.linkResolver({
-        type: 'career',
-        uid: 'post'
-      } as any);
-
-      expect(res).toBe('/careers/post');
-    });
-
-    it('should return `/` by default', () => {
-      const res = comp.linkResolver({} as any);
-
-      expect(res).toBe('/');
-    });
-  });
-
   describe('Template', () => {
     describe('Has `data`', () => {
       beforeEach(() => {
@@ -75,15 +51,13 @@ describe('TextBlockComponent', () => {
       });
 
       it('should be displayed', () => {
-        expect(page.text.innerHTML).toBe(
-          '<p>This is a sentence.</p><p><strong>This is a bold sentence.</strong></p>'
-        );
+        expect(page.text.innerHTML).toBeTruthy();
       });
 
-      it('should call RichText `asHtml` with `data` and `linkResolver` args', () => {
-        expect(RichText.asHtml).toHaveBeenCalledWith(
+      it('should call `PrismicTextPipe` with `data` arg', () => {
+        expect(MockPrismicTextPipe.prototype.transform).toHaveBeenCalledWith(
           comp.data,
-          comp.linkResolver
+          'asHtml'
         );
       });
     });
@@ -118,7 +92,7 @@ function createComponent() {
     By.directive(PrismicTextBlockComponent)
   );
   comp = el.injector.get<PrismicTextBlockComponent>(PrismicTextBlockComponent);
-  jest.spyOn(RichText, 'asHtml');
+  jest.spyOn(MockPrismicTextPipe.prototype, 'transform');
   page = new Page();
 
   fixture.detectChanges();

--- a/packages/angular/src/app/shared/blocks/prismic-text-block/prismic-text-block.component.ts
+++ b/packages/angular/src/app/shared/blocks/prismic-text-block/prismic-text-block.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
-import { RichText } from 'prismic-dom';
-
-import { NewsPost, CareerPost, Text } from 'prismic';
+import { Text } from 'prismic';
 
 @Component({
   selector: 'prismic-text-block',
@@ -14,19 +12,5 @@ import { NewsPost, CareerPost, Text } from 'prismic';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PrismicTextBlockComponent {
-  richText = RichText;
-
-  @Input()
-  data: Text[] | undefined;
-
-  linkResolver({ type, uid }: NewsPost | CareerPost): string {
-    switch (type) {
-      case 'news':
-        return `/news/${uid}`;
-      case 'career':
-        return `/careers/${uid}`;
-      default:
-        return '/';
-    }
-  }
+  @Input() data: Text[] | undefined;
 }

--- a/packages/angular/src/app/shared/pipes/prismic-text.helpers.spec.ts
+++ b/packages/angular/src/app/shared/pipes/prismic-text.helpers.spec.ts
@@ -1,0 +1,27 @@
+import { linkResolver } from './prismic-text.helpers';
+
+describe('`linkResolver`', () => {
+  it('should return `/news/$uid` if `type` arg is `news`', () => {
+    const res = linkResolver({
+      type: 'news',
+      uid: 'post'
+    } as any);
+
+    expect(res).toBe('/news/post');
+  });
+
+  it('should return `/careers/$uid` if `type` arg is `career`', () => {
+    const res = linkResolver({
+      type: 'career',
+      uid: 'post'
+    } as any);
+
+    expect(res).toBe('/careers/post');
+  });
+
+  it('should return `/` by default', () => {
+    const res = linkResolver({} as any);
+
+    expect(res).toBe('/');
+  });
+});

--- a/packages/angular/src/app/shared/pipes/prismic-text.helpers.ts
+++ b/packages/angular/src/app/shared/pipes/prismic-text.helpers.ts
@@ -1,0 +1,12 @@
+import { NewsPost, CareerPost } from 'prismic';
+
+export const linkResolver = ({ type, uid }: NewsPost | CareerPost): string => {
+  switch (type) {
+    case 'news':
+      return `/news/${uid}`;
+    case 'career':
+      return `/careers/${uid}`;
+    default:
+      return '/';
+  }
+};

--- a/packages/angular/src/app/shared/pipes/prismic-text.pipe.spec.ts
+++ b/packages/angular/src/app/shared/pipes/prismic-text.pipe.spec.ts
@@ -1,0 +1,63 @@
+import { RichText } from 'prismic-dom';
+
+import { Data } from 'testing';
+import { PrismicTextPipe } from './prismic-text.pipe';
+
+let pipe: PrismicTextPipe;
+
+jest.mock('./prismic-text.helpers', () => ({
+  linkResolver: 'linkResolver'
+}));
+
+jest.spyOn(RichText, 'asText');
+jest.spyOn(RichText, 'asHtml');
+
+describe('PrismicTextPipe', () => {
+  beforeEach(() => (pipe = new PrismicTextPipe()));
+
+  it('should create pipe', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  describe('`transform`', () => {
+    describe('`type` is `asText`', () => {
+      it('should call `RichText` `asText` with `val` arg', () => {
+        (RichText.asText as jest.Mock).mockReturnValueOnce('');
+        pipe.transform('val', 'asText');
+
+        expect(RichText.asText).toHaveBeenCalledWith('val');
+      });
+
+      it('should return `RichText` `asText`', () => {
+        const res = pipe.transform(Data.Prismic.getText(), 'asText');
+
+        expect(res).toBe('This is a sentence. This is a bold sentence.');
+      });
+    });
+
+    describe('`type` is `asHtml`', () => {
+      it('should call `RichText` `asHtml` with `val` and `linkResolver` args', () => {
+        (RichText.asHtml as jest.Mock).mockReturnValueOnce('');
+        pipe.transform('val', 'asHtml');
+
+        expect(RichText.asHtml).toHaveBeenCalledWith('val', 'linkResolver');
+      });
+
+      it('should return `RichText` `asHtml`', () => {
+        const res = pipe.transform(Data.Prismic.getText(), 'asHtml');
+
+        expect(res).toBe(
+          '<p>This is a sentence.</p><p><strong>This is a bold sentence.</strong></p>'
+        );
+      });
+    });
+
+    describe('`type` is unknown', () => {
+      it('should throw error', () => {
+        const res = () => pipe.transform('val', 'unknown' as any);
+
+        expect(res).toThrowError('Unsupported `type`');
+      });
+    });
+  });
+});

--- a/packages/angular/src/app/shared/pipes/prismic-text.pipe.ts
+++ b/packages/angular/src/app/shared/pipes/prismic-text.pipe.ts
@@ -1,0 +1,21 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { RichText } from 'prismic-dom';
+
+import { linkResolver } from './prismic-text.helpers';
+
+@Pipe({
+  name: 'prismicText'
+})
+export class PrismicTextPipe implements PipeTransform {
+  transform(val: any, type: 'asText' | 'asHtml') {
+    switch (type) {
+      case 'asText':
+        return RichText.asText(val);
+      case 'asHtml':
+        return RichText.asHtml(val, linkResolver);
+      default:
+        throw new Error('Unsupported `type`');
+    }
+  }
+}

--- a/packages/angular/src/app/shared/shared.module.ts
+++ b/packages/angular/src/app/shared/shared.module.ts
@@ -21,6 +21,7 @@ import { VideoBlockComponent } from './blocks/video-block/video-block.component'
 import { AudioBlockComponent } from './blocks/audio-block/audio-block.component';
 import { ApiPipe } from './pipes/api.pipe';
 import { PrismicPipe } from './pipes/prismic.pipe';
+import { PrismicTextPipe } from './pipes/prismic-text.pipe';
 import { LazyDirective } from './lazy.directive';
 import { ErrorComponent } from './errors/error/error.component';
 
@@ -44,7 +45,8 @@ import { ErrorComponent } from './errors/error/error.component';
     FormComponent,
     LazyDirective,
     ApiPipe,
-    PrismicPipe
+    PrismicPipe,
+    PrismicTextPipe
   ],
   exports: [
     HeaderComponent,
@@ -63,7 +65,8 @@ import { ErrorComponent } from './errors/error/error.component';
     ErrorComponent,
     LazyDirective,
     ApiPipe,
-    PrismicPipe
+    PrismicPipe,
+    PrismicTextPipe
   ],
   providers: [ApiPipe]
 })

--- a/packages/angular/src/testing/index.ts
+++ b/packages/angular/src/testing/index.ts
@@ -9,6 +9,7 @@ export * from './prismic.pipe.mock';
 export * from './router';
 export * from './sanitizer';
 export * from './material';
+export * from './prismic-text.pipe.mock';
 
 export * from './directives';
 export * from './components';

--- a/packages/angular/src/testing/prismic-text.pipe.mock.ts
+++ b/packages/angular/src/testing/prismic-text.pipe.mock.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'prismicText'
+})
+export class MockPrismicTextPipe implements PipeTransform {
+  transform(val: any): any {
+    return { 'mock-prismic-text-pipe': val };
+  }
+}


### PR DESCRIPTION
Previously, all components that needed to extract text from prismic bound to `RichText`. This meant that angular would call this external function several times during rendering.
This commit removes those individual bindings and creates a pure `PrismicTextPipe` that calls `RichText`. This means that angular will only call this pipe and `RichText` when inputs change, instead of at every cd cycle