### PR TITLE
refactor(angular): use `async` pipe

### DIFF
--- a/packages/angular/src/app/pages/careers/career/career.component.html
+++ b/packages/angular/src/app/pages/careers/career/career.component.html
@@ -1,50 +1,52 @@
-<error *ngIf="career === null"></error>
+<ng-container *ngIf="(career$ | async) as career">
+  <ng-template #noCareer><error></error></ng-template>
 
-<ng-container *ngIf="career">
-  <section id="intro">
-    <div id="intro-info">
-      <h1 *ngIf="career?.data?.title">
-        {{ career?.data?.title | prismicText: 'asText' }}
-      </h1>
-      <h2>{{ career?.data?.salary }}</h2>
-    </div>
-  </section>
+  <ng-container *ngIf="career?.post; else: noCareer">
+    <section id="intro">
+      <div id="intro-info">
+        <h1 *ngIf="career?.post?.data?.title">
+          {{ career?.post?.data?.title | prismicText: 'asText' }}
+        </h1>
+        <h2>{{ career?.post?.data?.salary }}</h2>
+      </div>
+    </section>
 
-  <ng-container *ngFor="let slice of career?.data?.body">
-    <ng-container [ngSwitch]="slice?.slice_type">
-      <prismic-text-block
-        *ngSwitchCase="'text'"
-        [data]="slice?.primary?.text"
-      ></prismic-text-block>
+    <ng-container *ngFor="let slice of career?.post?.data?.body">
+      <ng-container [ngSwitch]="slice?.slice_type">
+        <prismic-text-block
+          *ngSwitchCase="'text'"
+          [data]="slice?.primary?.text"
+        ></prismic-text-block>
+      </ng-container>
     </ng-container>
+
+    <section>
+      <div class="text">
+        <h2>Benefits</h2>
+        <ul>
+          <li>Excellent and competitive rates of pay</li>
+          <li>
+            20 days holiday a year plus bank holidays, rising to 25 days plus
+            bank holidays after first year
+          </li>
+          <li>Full time job within a creative &amp; vibrant team</li>
+          <li>Opportunities for professional career development</li>
+          <li>Childcare vouchers and contributory pension scheme</li>
+          <li>
+            A great opportunity to work for a leading and established creative
+            agency
+          </li>
+          <li>Free on-site car parking</li>
+        </ul>
+      </div>
+    </section>
+
+    <a
+      class="button black"
+      href="mailto:{{ career?.post?.data?.contact }}"
+      [attr.aria-label]="'Apply Now'"
+    >
+      APPLY NOW
+    </a>
   </ng-container>
-
-  <section>
-    <div class="text">
-      <h2>Benefits</h2>
-      <ul>
-        <li>Excellent and competitive rates of pay</li>
-        <li>
-          20 days holiday a year plus bank holidays, rising to 25 days plus bank
-          holidays after first year
-        </li>
-        <li>Full time job within a creative &amp; vibrant team</li>
-        <li>Opportunities for professional career development</li>
-        <li>Childcare vouchers and contributory pension scheme</li>
-        <li>
-          A great opportunity to work for a leading and established creative
-          agency
-        </li>
-        <li>Free on-site car parking</li>
-      </ul>
-    </div>
-  </section>
-
-  <a
-    class="button black"
-    href="mailto:{{ career?.data?.contact }}"
-    [attr.aria-label]="'Apply Now'"
-  >
-    APPLY NOW
-  </a>
 </ng-container>

--- a/packages/angular/src/app/pages/careers/career/career.component.spec.ts
+++ b/packages/angular/src/app/pages/careers/career/career.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ChangeDetectorRef } from '@angular/core';
 
 import {
   RouterTestingModule,
@@ -23,7 +22,6 @@ let comp: CareerComponent;
 let fixture: ComponentFixture<CareerComponent>;
 let page: Page;
 let activatedRoute: ActivatedRouteStub;
-let changeDetectorRef: ChangeDetectorRef;
 let prismicService: PrismicService;
 
 beforeEach(jest.clearAllMocks);
@@ -55,8 +53,8 @@ describe('CareerComponent', () => {
   });
 
   describe('`ngOnInit`', () => {
-    it('should set `careerSub`', () => {
-      expect(comp.careerSub).toBeDefined();
+    it('should set `career$`', () => {
+      expect(comp.career$).toBeDefined();
     });
 
     it('should call `PrismicService` `getPost` with `career` and `uid` param args if `uid` param exists', () => {
@@ -72,57 +70,15 @@ describe('CareerComponent', () => {
 
       expect(prismicService.getPost).not.toHaveBeenCalled();
     });
-
-    it('should set `career`', () => {
-      prismicService.getPost = jest.fn().mockReturnValue(of('getPostReturn'));
-      activatedRoute.testParamMap = { uid: 'uid' };
-
-      expect(comp.career).toBe('getPostReturn');
-    });
-
-    it('should call `ChangeDetectorRef` `markForCheck`', () => {
-      activatedRoute.testParamMap = { uid: 'uid' };
-
-      expect(changeDetectorRef.markForCheck).toHaveBeenCalled();
-    });
-  });
-
-  describe('`ngOnDestroy`', () => {
-    it('should call `careerSub` `unsubscribe` if has `careerSub', () => {
-      comp.careerSub = { unsubscribe: jest.fn() } as any;
-      comp.ngOnDestroy();
-
-      expect((comp.careerSub as any).unsubscribe).toHaveBeenCalled();
-    });
-
-    it('should not throw if no `careerSub`', () => {
-      comp.careerSub = undefined;
-
-      expect(() => comp.ngOnDestroy()).not.toThrow();
-    });
   });
 
   describe('Template', () => {
-    describe('`career` is `undefined`', () => {
+    describe('`career.post` is `null`', () => {
       beforeEach(() => {
-        comp.career = undefined;
-        changeDetectorRef.markForCheck();
-        fixture.detectChanges();
-      });
-
-      it('should not display `ErrorComponent`', () => {
-        expect(page.error).toBeFalsy();
-      });
-
-      it('should not display title', () => {
-        expect(page.title).toBeFalsy();
-      });
-    });
-
-    describe('`career` is `null`', () => {
-      beforeEach(() => {
-        comp.career = null;
-        changeDetectorRef.markForCheck();
+        (prismicService.getPost as jest.Mock).mockReturnValue(
+          of({ post: null })
+        );
+        activatedRoute.testParamMap = { uid: 'uid' };
         fixture.detectChanges();
       });
 
@@ -135,10 +91,12 @@ describe('CareerComponent', () => {
       });
     });
 
-    describe('Has `career`', () => {
+    describe('Has `career.post`', () => {
       beforeEach(() => {
-        comp.career = Data.Prismic.getCareerPost();
-        changeDetectorRef.markForCheck();
+        (prismicService.getPost as jest.Mock).mockReturnValue(
+          of({ post: Data.Prismic.getCareerPost() })
+        );
+        activatedRoute.testParamMap = { uid: 'uid' };
         fixture.detectChanges();
       });
 
@@ -147,12 +105,16 @@ describe('CareerComponent', () => {
       });
 
       describe('Title', () => {
-        describe('Has `career.data.title`', () => {
+        describe('Has `career.post.data.title`', () => {
           beforeEach(() => {
-            comp.career = ({
-              data: { title: [{ spans: [], text: 'Title', type: 'h1' }] }
-            } as any) as CareerPost;
-            changeDetectorRef.markForCheck();
+            (prismicService.getPost as jest.Mock).mockReturnValue(
+              of({
+                post: ({
+                  data: { title: [{ spans: [], text: 'Title', type: 'h1' }] }
+                } as any) as CareerPost
+              })
+            );
+            activatedRoute.testParamMap = { uid: 'uid' };
             fixture.detectChanges();
           });
 
@@ -160,7 +122,7 @@ describe('CareerComponent', () => {
             expect(page.title.textContent).toBeTruthy();
           });
 
-          it('should call `PrismicTextPipe` with `career.data.title` arg', () => {
+          it('should call `PrismicTextPipe` with `career.post.data.title` arg', () => {
             expect(
               MockPrismicTextPipe.prototype.transform
             ).toHaveBeenCalledWith(
@@ -170,12 +132,16 @@ describe('CareerComponent', () => {
           });
         });
 
-        describe('No `career.data.title`', () => {
+        describe('No `career.post.data.title`', () => {
           beforeEach(() => {
-            comp.career = ({
-              data: { title: undefined }
-            } as any) as CareerPost;
-            changeDetectorRef.markForCheck();
+            (prismicService.getPost as jest.Mock).mockReturnValue(
+              of({
+                post: ({
+                  data: { title: undefined }
+                } as any) as CareerPost
+              })
+            );
+            activatedRoute.testParamMap = { uid: 'uid' };
             fixture.detectChanges();
           });
 
@@ -192,8 +158,10 @@ describe('CareerComponent', () => {
       describe('Section', () => {
         describe('Text', () => {
           beforeEach(() => {
-            comp.career = Data.Prismic.getNewsPosts('post-2') as any;
-            changeDetectorRef.markForCheck();
+            (prismicService.getPost as jest.Mock).mockReturnValue(
+              of({ post: Data.Prismic.getNewsPosts('post-2') as any })
+            );
+            activatedRoute.testParamMap = { uid: 'uid' };
             fixture.detectChanges();
           });
 
@@ -214,7 +182,7 @@ describe('CareerComponent', () => {
           expect(page.applyButton).toBeTruthy();
         });
 
-        it('should set `href` as `career.data.contact`', () => {
+        it('should set `href` as `career.post.data.contact`', () => {
           expect(page.applyButton.href).toBe('mailto:post@contact');
         });
       });
@@ -256,14 +224,12 @@ class Page {
 function createComponent() {
   fixture = TestBed.createComponent(CareerComponent);
   comp = fixture.componentInstance;
-  changeDetectorRef = (comp as any).changeDetectorRef;
   prismicService = fixture.debugElement.injector.get<PrismicService>(
     PrismicService
   );
   page = new Page();
 
   jest.spyOn(MockPrismicTextPipe.prototype, 'transform');
-  jest.spyOn(changeDetectorRef, 'markForCheck');
   fixture.detectChanges();
   return fixture.whenStable().then(_ => fixture.detectChanges());
 }

--- a/packages/angular/src/app/pages/careers/career/career.component.ts
+++ b/packages/angular/src/app/pages/careers/career/career.component.ts
@@ -1,17 +1,10 @@
-import {
-  Component,
-  OnInit,
-  OnDestroy,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef
-} from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 
-import { Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { switchMap, map, filter } from 'rxjs/operators';
 
-import { PrismicService } from 'shared';
-import { CareerPost } from 'prismic';
+import { PrismicService, PostReturn } from 'shared';
 
 @Component({
   selector: 'app-career',
@@ -19,30 +12,19 @@ import { CareerPost } from 'prismic';
   styleUrls: ['./career.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class CareerComponent implements OnInit, OnDestroy {
-  careerSub: Subscription | undefined;
-  career: CareerPost | null | undefined;
+export class CareerComponent implements OnInit {
+  career$: Observable<PostReturn<'career'>> | undefined;
 
   constructor(
     private route: ActivatedRoute,
-    private changeDetectorRef: ChangeDetectorRef,
     private prismicService: PrismicService
   ) {}
 
   ngOnInit() {
-    this.careerSub = this.route.paramMap
-      .pipe(
-        map((params: ParamMap) => params.get('uid')),
-        filter((uid): uid is string => Boolean(uid)),
-        switchMap(uid => this.prismicService.getPost('career', uid))
-      )
-      .subscribe(career => {
-        this.career = career;
-        this.changeDetectorRef.markForCheck();
-      });
-  }
-
-  ngOnDestroy() {
-    this.careerSub && this.careerSub.unsubscribe();
+    this.career$ = this.route.paramMap.pipe(
+      map((params: ParamMap) => params.get('uid')),
+      filter((uid): uid is string => Boolean(uid)),
+      switchMap(uid => this.prismicService.getPost('career', uid))
+    );
   }
 }

--- a/packages/angular/src/app/pages/news/news-post/news-post.component.html
+++ b/packages/angular/src/app/pages/news/news-post/news-post.component.html
@@ -1,44 +1,46 @@
-<error *ngIf="post === null"></error>
+<ng-container *ngIf="(news$ | async) as news">
+  <ng-template #noNews><error></error></ng-template>
 
-<ng-container *ngIf="post">
-  <section id="intro">
-    <div id="intro-info">
-      <span id="info-date">
-        {{ post?.first_publication_date | date: 'dd LLLL' }}
-      </span>
-      <h1 *ngIf="post?.data?.title">
-        {{ post?.data?.title | prismicText: 'asText' }}
-      </h1>
-    </div>
-    <image-component
-      *ngIf="post?.data?.image?.proxy?.url"
-      [image]="post?.data | prismic"
-      full-height
-    ></image-component>
-  </section>
+  <ng-container *ngIf="news?.post; else: noNews">
+    <section id="intro">
+      <div id="intro-info">
+        <span id="info-date">
+          {{ news?.post?.first_publication_date | date: 'dd LLLL' }}
+        </span>
+        <h1 *ngIf="news?.post?.data?.title">
+          {{ news?.post?.data?.title | prismicText: 'asText' }}
+        </h1>
+      </div>
+      <image-component
+        *ngIf="news?.post?.data?.image?.proxy?.url"
+        [image]="news?.post?.data | prismic"
+        full-height
+      ></image-component>
+    </section>
 
-  <ng-container *ngFor="let slice of post?.data?.body">
-    <ng-container [ngSwitch]="slice?.slice_type">
-      <prismic-text-block
-        *ngSwitchCase="'text'"
-        [data]="slice?.primary?.text"
-      ></prismic-text-block>
-      <image-block
-        *ngSwitchCase="'image'"
-        [data]="slice?.primary | prismic"
-      ></image-block>
-      <duo-block
-        *ngSwitchCase="'duo'"
-        [data]="slice?.items | prismic"
-      ></duo-block>
-      <gallery-block
-        *ngSwitchCase="'gallery'"
-        [data]="slice?.items | prismic"
-      ></gallery-block>
-      <video-block
-        *ngSwitchCase="'video'"
-        [data]="slice?.primary | prismic"
-      ></video-block>
+    <ng-container *ngFor="let slice of news?.post?.data?.body">
+      <ng-container [ngSwitch]="slice?.slice_type">
+        <prismic-text-block
+          *ngSwitchCase="'text'"
+          [data]="slice?.primary?.text"
+        ></prismic-text-block>
+        <image-block
+          *ngSwitchCase="'image'"
+          [data]="slice?.primary | prismic"
+        ></image-block>
+        <duo-block
+          *ngSwitchCase="'duo'"
+          [data]="slice?.items | prismic"
+        ></duo-block>
+        <gallery-block
+          *ngSwitchCase="'gallery'"
+          [data]="slice?.items | prismic"
+        ></gallery-block>
+        <video-block
+          *ngSwitchCase="'video'"
+          [data]="slice?.primary | prismic"
+        ></video-block>
+      </ng-container>
     </ng-container>
   </ng-container>
 </ng-container>

--- a/packages/angular/src/app/pages/news/news-post/news-post.component.spec.ts
+++ b/packages/angular/src/app/pages/news/news-post/news-post.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ChangeDetectorRef } from '@angular/core';
 
 import {
   RouterTestingModule,
@@ -26,7 +25,6 @@ import { NewsPostComponent } from './news-post.component';
 let activatedRoute: ActivatedRouteStub;
 let comp: NewsPostComponent;
 let fixture: ComponentFixture<NewsPostComponent>;
-let changeDetectorRef: ChangeDetectorRef;
 let prismicService: PrismicService;
 let page: Page;
 
@@ -65,8 +63,8 @@ describe('NewsPostComponent', () => {
   });
 
   describe('`ngOnInit`', () => {
-    it('should set `postSub`', () => {
-      expect(comp.postSub).toBeDefined();
+    it('should set `news$`', () => {
+      expect(comp.news$).toBeDefined();
     });
 
     it('should call `PrismicService` `getPost` with `news` and `uid` param arg if `uid` param exists', () => {
@@ -82,57 +80,15 @@ describe('NewsPostComponent', () => {
 
       expect(prismicService.getPost).not.toHaveBeenCalled();
     });
-
-    it('should set `post`', () => {
-      prismicService.getPost = jest.fn().mockReturnValue(of('getPostReturn'));
-      activatedRoute.testParamMap = { uid: 'uid' };
-
-      expect(comp.post).toBe('getPostReturn');
-    });
-
-    it('should call `ChangeDetectorRef` `markForCheck`', () => {
-      expect(changeDetectorRef.markForCheck).toHaveBeenCalled();
-    });
-  });
-
-  describe('`ngOnDestroy`', () => {
-    it('should call `postSub` `unsubscribe` if has `postSub', () => {
-      comp.postSub = { unsubscribe: jest.fn() } as any;
-      comp.ngOnDestroy();
-
-      expect((comp.postSub as any).unsubscribe).toHaveBeenCalled();
-    });
-
-    it('should not throw if no `postSub`', () => {
-      comp.postSub = undefined;
-
-      expect(() => comp.ngOnDestroy()).not.toThrow();
-    });
   });
 
   describe('Template', () => {
-    describe('`post` is `undefined`', () => {
+    describe('`news.post` is `null`', () => {
       beforeEach(() => {
-        comp.post = undefined;
-        changeDetectorRef.markForCheck();
-        fixture.detectChanges();
-      });
-
-      it('should not display `ErrorComponent`', () => {
-        expect(page.error).toBeFalsy();
-      });
-
-      describe('Intro', () => {
-        it('should not display date', () => {
-          expect(page.date).toBeFalsy();
-        });
-      });
-    });
-
-    describe('`post` is `null`', () => {
-      beforeEach(() => {
-        comp.post = null;
-        changeDetectorRef.markForCheck();
+        (prismicService.getPost as jest.Mock).mockReturnValue(
+          of({ post: null })
+        );
+        activatedRoute.testParamMap = { uid: 'uid' };
         fixture.detectChanges();
       });
 
@@ -147,10 +103,12 @@ describe('NewsPostComponent', () => {
       });
     });
 
-    describe('Has `post`', () => {
+    describe('Has `news.post`', () => {
       beforeEach(() => {
-        comp.post = Data.Prismic.getNewsPosts('post-1');
-        changeDetectorRef.markForCheck();
+        (prismicService.getPost as jest.Mock).mockReturnValue(
+          of({ post: Data.Prismic.getNewsPosts('post-1') })
+        );
+        activatedRoute.testParamMap = { uid: 'uid' };
         fixture.detectChanges();
       });
 
@@ -166,8 +124,10 @@ describe('NewsPostComponent', () => {
         describe('Title', () => {
           describe('has `title`', () => {
             beforeEach(() => {
-              comp.post = Data.Prismic.getNewsPost();
-              changeDetectorRef.markForCheck();
+              (prismicService.getPost as jest.Mock).mockReturnValue(
+                of({ post: Data.Prismic.getNewsPost() })
+              );
+              activatedRoute.testParamMap = { uid: 'uid' };
               fixture.detectChanges();
             });
 
@@ -187,11 +147,18 @@ describe('NewsPostComponent', () => {
 
           describe('no `title`', () => {
             beforeEach(() => {
-              comp.post = {
-                ...Data.Prismic.getNewsPost(),
-                data: { ...Data.Prismic.getNewsPost().data, title: undefined }
-              } as any;
-              changeDetectorRef.markForCheck();
+              (prismicService.getPost as jest.Mock).mockReturnValue(
+                of({
+                  post: {
+                    ...Data.Prismic.getNewsPost(),
+                    data: {
+                      ...Data.Prismic.getNewsPost().data,
+                      title: undefined
+                    }
+                  } as any
+                })
+              );
+              activatedRoute.testParamMap = { uid: 'uid' };
               fixture.detectChanges();
             });
 
@@ -204,20 +171,24 @@ describe('NewsPostComponent', () => {
         describe('Thumbnail', () => {
           describe('has `image.proxy.url`', () => {
             beforeEach(() => {
-              comp.post = {
-                ...Data.Prismic.getNewsPost(),
-                data: {
-                  ...Data.Prismic.getNewsPost().data,
-                  image: {
-                    ...Data.Prismic.getNewsPost().data.image,
-                    proxy: {
-                      ...Data.Prismic.getNewsPost().data.image.proxy,
-                      url: 'test.jpg'
+              (prismicService.getPost as jest.Mock).mockReturnValue(
+                of({
+                  post: {
+                    ...Data.Prismic.getNewsPost(),
+                    data: {
+                      ...Data.Prismic.getNewsPost().data,
+                      image: {
+                        ...Data.Prismic.getNewsPost().data.image,
+                        proxy: {
+                          ...Data.Prismic.getNewsPost().data.image.proxy,
+                          url: 'test.jpg'
+                        }
+                      }
                     }
-                  }
-                }
-              } as any;
-              changeDetectorRef.markForCheck();
+                  } as any
+                })
+              );
+              activatedRoute.testParamMap = { uid: 'uid' };
               fixture.detectChanges();
             });
 
@@ -260,20 +231,24 @@ describe('NewsPostComponent', () => {
 
           describe('no `image.proxy.url`', () => {
             beforeEach(() => {
-              comp.post = {
-                ...Data.Prismic.getNewsPost(),
-                data: {
-                  ...Data.Prismic.getNewsPost().data,
-                  image: {
-                    ...Data.Prismic.getNewsPost().data.image,
-                    proxy: {
-                      ...Data.Prismic.getNewsPost().data.image.proxy,
-                      url: undefined
+              (prismicService.getPost as jest.Mock).mockReturnValue(
+                of({
+                  post: {
+                    ...Data.Prismic.getNewsPost(),
+                    data: {
+                      ...Data.Prismic.getNewsPost().data,
+                      image: {
+                        ...Data.Prismic.getNewsPost().data.image,
+                        proxy: {
+                          ...Data.Prismic.getNewsPost().data.image.proxy,
+                          url: undefined
+                        }
+                      }
                     }
-                  }
-                }
-              } as any;
-              changeDetectorRef.markForCheck();
+                  } as any
+                })
+              );
+              activatedRoute.testParamMap = { uid: 'uid' };
               fixture.detectChanges();
             });
 
@@ -287,8 +262,10 @@ describe('NewsPostComponent', () => {
       describe('Content', () => {
         describe('Text', () => {
           beforeEach(() => {
-            comp.post = Data.Prismic.getNewsPosts('post-2');
-            changeDetectorRef.markForCheck();
+            (prismicService.getPost as jest.Mock).mockReturnValue(
+              of({ post: Data.Prismic.getNewsPosts('post-2') })
+            );
+            activatedRoute.testParamMap = { uid: 'uid' };
             fixture.detectChanges();
           });
 
@@ -313,8 +290,10 @@ describe('NewsPostComponent', () => {
 
         describe('Image', () => {
           beforeEach(() => {
-            comp.post = Data.Prismic.getNewsPosts('post-3');
-            changeDetectorRef.markForCheck();
+            (prismicService.getPost as jest.Mock).mockReturnValue(
+              of({ post: Data.Prismic.getNewsPosts('post-3') })
+            );
+            activatedRoute.testParamMap = { uid: 'uid' };
             fixture.detectChanges();
           });
 
@@ -338,8 +317,10 @@ describe('NewsPostComponent', () => {
 
         describe('Duo', () => {
           beforeEach(() => {
-            comp.post = Data.Prismic.getNewsPosts('post-4');
-            changeDetectorRef.markForCheck();
+            (prismicService.getPost as jest.Mock).mockReturnValue(
+              of({ post: Data.Prismic.getNewsPosts('post-4') })
+            );
+            activatedRoute.testParamMap = { uid: 'uid' };
             fixture.detectChanges();
           });
 
@@ -363,8 +344,10 @@ describe('NewsPostComponent', () => {
 
         describe('Gallery', () => {
           beforeEach(() => {
-            comp.post = Data.Prismic.getNewsPosts('post-5');
-            changeDetectorRef.markForCheck();
+            (prismicService.getPost as jest.Mock).mockReturnValue(
+              of({ post: Data.Prismic.getNewsPosts('post-5') })
+            );
+            activatedRoute.testParamMap = { uid: 'uid' };
             fixture.detectChanges();
           });
 
@@ -388,8 +371,10 @@ describe('NewsPostComponent', () => {
 
         describe('Video', () => {
           beforeEach(() => {
-            comp.post = Data.Prismic.getNewsPosts('post-6');
-            changeDetectorRef.markForCheck();
+            (prismicService.getPost as jest.Mock).mockReturnValue(
+              of({ post: Data.Prismic.getNewsPosts('post-6') })
+            );
+            activatedRoute.testParamMap = { uid: 'uid' };
             fixture.detectChanges();
           });
 
@@ -499,11 +484,9 @@ class Page {
 function createComponent() {
   fixture = TestBed.createComponent(NewsPostComponent);
   comp = fixture.componentInstance;
-  changeDetectorRef = (comp as any).changeDetectorRef;
   prismicService = fixture.debugElement.injector.get<PrismicService>(
     PrismicService
   );
-  jest.spyOn(changeDetectorRef, 'markForCheck');
   jest.spyOn(MockPrismicPipe.prototype, 'transform');
   jest.spyOn(MockPrismicTextPipe.prototype, 'transform');
   page = new Page();

--- a/packages/angular/src/app/pages/news/news-post/news-post.component.ts
+++ b/packages/angular/src/app/pages/news/news-post/news-post.component.ts
@@ -1,17 +1,10 @@
-import {
-  Component,
-  OnInit,
-  OnDestroy,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef
-} from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 
-import { Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { switchMap, map, filter } from 'rxjs/operators';
 
-import { PrismicService } from 'shared';
-import { NewsPost } from 'prismic';
+import { PrismicService, PostReturn } from 'shared';
 
 @Component({
   selector: 'app-news-post',
@@ -19,30 +12,19 @@ import { NewsPost } from 'prismic';
   styleUrls: ['./news-post.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class NewsPostComponent implements OnInit, OnDestroy {
-  postSub: Subscription | undefined;
-  post: NewsPost | null | undefined;
+export class NewsPostComponent implements OnInit {
+  news$: Observable<PostReturn<'news'>> | undefined;
 
   constructor(
     private route: ActivatedRoute,
-    private changeDetectorRef: ChangeDetectorRef,
     private prismicService: PrismicService
   ) {}
 
   ngOnInit() {
-    this.postSub = this.route.paramMap
-      .pipe(
-        map((params: ParamMap) => params.get('uid')),
-        filter((uid): uid is string => Boolean(uid)),
-        switchMap(uid => this.prismicService.getPost('news', uid))
-      )
-      .subscribe(post => {
-        this.post = post;
-        this.changeDetectorRef.markForCheck();
-      });
-  }
-
-  ngOnDestroy() {
-    this.postSub && this.postSub.unsubscribe();
+    this.news$ = this.route.paramMap.pipe(
+      map((params: ParamMap) => params.get('uid')),
+      filter((uid): uid is string => Boolean(uid)),
+      switchMap(uid => this.prismicService.getPost('news', uid))
+    );
   }
 }

--- a/packages/angular/src/app/shared/index.ts
+++ b/packages/angular/src/app/shared/index.ts
@@ -1,5 +1,6 @@
 export * from './api.service';
 export * from './prismic.service';
+export { PostReturn, PostsReturn } from './prismic.service.helpers';
 export * from './email.service';
 export * from './meta.service';
 export * from './logger.service';

--- a/packages/angular/src/app/shared/prismic.service.helpers.ts
+++ b/packages/angular/src/app/shared/prismic.service.helpers.ts
@@ -1,7 +1,12 @@
 import { MetaTags } from 'shared';
-import { NewsPost, CareerPost } from 'prismic';
+import { NewsPost, CareerPost, PostsResponse } from 'prismic';
 
-export type PostReturn<T> = T extends 'news'
+export type PostsReturn<T> = PostsResponse<PostTypeReturn<T>>;
+export interface PostReturn<T> {
+  post: PostTypeReturn<T> | null;
+}
+
+export type PostTypeReturn<T> = T extends 'news'
   ? NewsPost
   : T extends 'career'
   ? CareerPost

--- a/packages/angular/src/app/shared/prismic.service.spec.ts
+++ b/packages/angular/src/app/shared/prismic.service.spec.ts
@@ -290,42 +290,22 @@ describe('PrismicService', () => {
         });
 
         describe('No error', () => {
-          describe('Has `post`', () => {
-            it('should return `post`', async(() => {
-              prismicService
-                .getPost('type' as any, 'uid')
-                .subscribe(res =>
-                  expect(res).toEqual(Data.Prismic.getNewsPosts('post-1'))
-                );
+          it('should return `post` as first `results` if exists', async(() => {
+            prismicService.getPost('type' as any, 'uid').subscribe(res =>
+              expect(res).toEqual({
+                post: Data.Prismic.getNewsPosts('post-1')
+              })
+            );
 
-              mockHttp
-                .expectOne(req => req.url === URL)
-                .flush(Data.Prismic.getNewsPostsResponse());
-            }));
+            mockHttp
+              .expectOne(req => req.url === URL)
+              .flush(Data.Prismic.getNewsPostsResponse());
+          }));
 
-            it('should call `createPostMetaTags` with `post` args', async(() => {
-              prismicService
-                .getPost('type' as any, 'uid')
-                .subscribe(_ =>
-                  expect(createPostMetaTags).toHaveBeenCalledWith(
-                    Data.Prismic.getNewsPosts('post-1')
-                  )
-                );
-
-              mockHttp
-                .expectOne(
-                  req =>
-                    req.url ===
-                    `${environment.prismic.endpoint}/documents/search`
-                )
-                .flush(Data.Prismic.getNewsPostsResponse());
-            }));
-          });
-
-          it('should return `null` if no `post`', async(() => {
+          it('should return `post` as `null` if `results` does not exist', async(() => {
             prismicService
               .getPost('type' as any, 'uid')
-              .subscribe(res => expect(res).toBe(null));
+              .subscribe(res => expect(res).toEqual({ post: null }));
 
             mockHttp
               .expectOne(
@@ -335,7 +315,7 @@ describe('PrismicService', () => {
               .flush({ results: [] });
           }));
 
-          it('should call `createPostMetaTags` with `post` args', async(() => {
+          it('should call `createPostMetaTags` with `res.post` args', async(() => {
             prismicService
               .getPost('type' as any, 'uid')
               .subscribe(_ =>

--- a/packages/angular/src/testing/prismic.service.mock.ts
+++ b/packages/angular/src/testing/prismic.service.mock.ts
@@ -1,8 +1,9 @@
 import { Observable, of } from 'rxjs';
-import { find, catchError, flatMap } from 'rxjs/operators';
+import { find, flatMap, map } from 'rxjs/operators';
 
 import { Data } from './';
 import { PostsResponse, NewsPost } from 'prismic';
+import { PostReturn } from 'shared';
 
 export class MockPrismicService {
   constructor() {
@@ -19,11 +20,11 @@ export class MockPrismicService {
     return of(Data.Prismic.getNewsPostsResponse());
   }
 
-  getPost(uid: string): Observable<NewsPost | undefined> {
+  getPost(uid: string): Observable<PostReturn<'news'>> {
     return of(Data.Prismic.getNewsPosts<void>()).pipe(
       flatMap(posts => posts),
       find(post => post.uid === uid),
-      catchError(_ => of(undefined))
+      map((post: any) => ({ post }))
     );
   }
 }


### PR DESCRIPTION
Previously, `PrismicService` `getPost` returned either `NewsPost`, `CareerPost`, or `null`. That meant that subscribers to `getPost` could not use `async` and instead had to subscribe manually, as `ngIf` would always return false for `null`. So, it was impossible to tell whether `post$` was just `undefined` or whether `getPost` actually returned `null`, and so we should show a 404 banner.
This commit changes `getPost` to return results wrapped in an object instead so that `async` can be used, and removes the manual subscription in `CareerComponent` and `NewsComponent`