### PR TITLE
refactor: only use initial route snapshot

### DIFF
--- a/packages/angular/src/app/pages/careers/career/career.component.spec.ts
+++ b/packages/angular/src/app/pages/careers/career/career.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { ChangeDetectionStrategy } from '@angular/core';
 
 import {
   RouterTestingModule,
@@ -29,7 +30,7 @@ beforeEach(jest.clearAllMocks);
 describe('CareerComponent', () => {
   beforeEach(async(() => {
     activatedRoute = new ActivatedRouteStub();
-    activatedRoute.testParamMap = { id: 'career-1' };
+    activatedRoute.testParamMap = { uid: 'career-1' };
 
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
@@ -43,7 +44,11 @@ describe('CareerComponent', () => {
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: PrismicService, useClass: MockPrismicService }
       ]
-    }).compileComponents();
+    })
+      .overrideComponent(CareerComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
   }));
 
   beforeEach(async(() => createComponent()));
@@ -60,25 +65,23 @@ describe('CareerComponent', () => {
     it('should call `PrismicService` `getPost` with `career` and `uid` param args if `uid` param exists', () => {
       jest.clearAllMocks();
       activatedRoute.testParamMap = { uid: 'uid' };
+      comp.ngOnInit();
 
       expect(prismicService.getPost).toHaveBeenCalledWith('career', 'uid');
     });
 
-    it('should not call `PrismicService` `getPost` if `uid` param does not exist', () => {
+    it('should throw if `uid` param does not exist', () => {
       jest.clearAllMocks();
       activatedRoute.testParamMap = { uid: undefined };
 
-      expect(prismicService.getPost).not.toHaveBeenCalled();
+      expect(() => comp.ngOnInit()).toThrowError('No `uid`');
     });
   });
 
   describe('Template', () => {
     describe('`career.post` is `null`', () => {
       beforeEach(() => {
-        (prismicService.getPost as jest.Mock).mockReturnValue(
-          of({ post: null })
-        );
-        activatedRoute.testParamMap = { uid: 'uid' };
+        comp.career$ = of({ post: null });
         fixture.detectChanges();
       });
 
@@ -93,10 +96,7 @@ describe('CareerComponent', () => {
 
     describe('Has `career.post`', () => {
       beforeEach(() => {
-        (prismicService.getPost as jest.Mock).mockReturnValue(
-          of({ post: Data.Prismic.getCareerPost() })
-        );
-        activatedRoute.testParamMap = { uid: 'uid' };
+        comp.career$ = of({ post: Data.Prismic.getCareerPost() });
         fixture.detectChanges();
       });
 
@@ -107,14 +107,11 @@ describe('CareerComponent', () => {
       describe('Title', () => {
         describe('Has `career.post.data.title`', () => {
           beforeEach(() => {
-            (prismicService.getPost as jest.Mock).mockReturnValue(
-              of({
-                post: ({
-                  data: { title: [{ spans: [], text: 'Title', type: 'h1' }] }
-                } as any) as CareerPost
-              })
-            );
-            activatedRoute.testParamMap = { uid: 'uid' };
+            comp.career$ = of({
+              post: ({
+                data: { title: [{ spans: [], text: 'Title', type: 'h1' }] }
+              } as any) as CareerPost
+            });
             fixture.detectChanges();
           });
 
@@ -134,14 +131,11 @@ describe('CareerComponent', () => {
 
         describe('No `career.post.data.title`', () => {
           beforeEach(() => {
-            (prismicService.getPost as jest.Mock).mockReturnValue(
-              of({
-                post: ({
-                  data: { title: undefined }
-                } as any) as CareerPost
-              })
-            );
-            activatedRoute.testParamMap = { uid: 'uid' };
+            comp.career$ = of({
+              post: ({
+                data: { title: undefined }
+              } as any) as CareerPost
+            });
             fixture.detectChanges();
           });
 
@@ -158,10 +152,9 @@ describe('CareerComponent', () => {
       describe('Section', () => {
         describe('Text', () => {
           beforeEach(() => {
-            (prismicService.getPost as jest.Mock).mockReturnValue(
-              of({ post: Data.Prismic.getNewsPosts('post-2') as any })
-            );
-            activatedRoute.testParamMap = { uid: 'uid' };
+            comp.career$ = of({
+              post: Data.Prismic.getNewsPosts('post-2') as any
+            });
             fixture.detectChanges();
           });
 

--- a/packages/angular/src/app/pages/careers/career/career.component.ts
+++ b/packages/angular/src/app/pages/careers/career/career.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { ActivatedRoute, ParamMap } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
 import { Observable } from 'rxjs';
-import { switchMap, map, filter } from 'rxjs/operators';
 
 import { PrismicService, PostReturn } from 'shared';
 
@@ -21,10 +20,9 @@ export class CareerComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.career$ = this.route.paramMap.pipe(
-      map((params: ParamMap) => params.get('uid')),
-      filter((uid): uid is string => Boolean(uid)),
-      switchMap(uid => this.prismicService.getPost('career', uid))
-    );
+    const uid = this.route.snapshot.paramMap.get('uid');
+    if (!uid) throw new Error('No `uid`');
+
+    this.career$ = this.prismicService.getPost('career', uid);
   }
 }

--- a/packages/angular/src/app/pages/news/news-post/news-post.component.spec.ts
+++ b/packages/angular/src/app/pages/news/news-post/news-post.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { ChangeDetectionStrategy } from '@angular/core';
 
 import {
   RouterTestingModule,
@@ -53,7 +54,11 @@ describe('NewsPostComponent', () => {
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: PrismicService, useClass: MockPrismicService }
       ]
-    }).compileComponents();
+    })
+      .overrideComponent(NewsPostComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
   }));
 
   beforeEach(async(() => createComponent()));
@@ -70,25 +75,23 @@ describe('NewsPostComponent', () => {
     it('should call `PrismicService` `getPost` with `news` and `uid` param arg if `uid` param exists', () => {
       jest.clearAllMocks();
       activatedRoute.testParamMap = { uid: 'uid' };
+      comp.ngOnInit();
 
       expect(prismicService.getPost).toHaveBeenCalledWith('news', 'uid');
     });
 
-    it('should not call `PrismicService` `getPost` if `uid` param does not exist', () => {
+    it('should throw if `uid` param does not exist', () => {
       jest.clearAllMocks();
       activatedRoute.testParamMap = { uid: undefined };
 
-      expect(prismicService.getPost).not.toHaveBeenCalled();
+      expect(() => comp.ngOnInit()).toThrowError('No `uid`');
     });
   });
 
   describe('Template', () => {
     describe('`news.post` is `null`', () => {
       beforeEach(() => {
-        (prismicService.getPost as jest.Mock).mockReturnValue(
-          of({ post: null })
-        );
-        activatedRoute.testParamMap = { uid: 'uid' };
+        comp.news$ = of({ post: null });
         fixture.detectChanges();
       });
 
@@ -105,10 +108,7 @@ describe('NewsPostComponent', () => {
 
     describe('Has `news.post`', () => {
       beforeEach(() => {
-        (prismicService.getPost as jest.Mock).mockReturnValue(
-          of({ post: Data.Prismic.getNewsPosts('post-1') })
-        );
-        activatedRoute.testParamMap = { uid: 'uid' };
+        comp.news$ = of({ post: Data.Prismic.getNewsPosts('post-1') });
         fixture.detectChanges();
       });
 
@@ -124,10 +124,7 @@ describe('NewsPostComponent', () => {
         describe('Title', () => {
           describe('has `title`', () => {
             beforeEach(() => {
-              (prismicService.getPost as jest.Mock).mockReturnValue(
-                of({ post: Data.Prismic.getNewsPost() })
-              );
-              activatedRoute.testParamMap = { uid: 'uid' };
+              comp.news$ = of({ post: Data.Prismic.getNewsPost() });
               fixture.detectChanges();
             });
 
@@ -147,18 +144,15 @@ describe('NewsPostComponent', () => {
 
           describe('no `title`', () => {
             beforeEach(() => {
-              (prismicService.getPost as jest.Mock).mockReturnValue(
-                of({
-                  post: {
-                    ...Data.Prismic.getNewsPost(),
-                    data: {
-                      ...Data.Prismic.getNewsPost().data,
-                      title: undefined
-                    }
-                  } as any
-                })
-              );
-              activatedRoute.testParamMap = { uid: 'uid' };
+              comp.news$ = of({
+                post: {
+                  ...Data.Prismic.getNewsPost(),
+                  data: {
+                    ...Data.Prismic.getNewsPost().data,
+                    title: undefined
+                  }
+                } as any
+              });
               fixture.detectChanges();
             });
 
@@ -171,24 +165,21 @@ describe('NewsPostComponent', () => {
         describe('Thumbnail', () => {
           describe('has `image.proxy.url`', () => {
             beforeEach(() => {
-              (prismicService.getPost as jest.Mock).mockReturnValue(
-                of({
-                  post: {
-                    ...Data.Prismic.getNewsPost(),
-                    data: {
-                      ...Data.Prismic.getNewsPost().data,
-                      image: {
-                        ...Data.Prismic.getNewsPost().data.image,
-                        proxy: {
-                          ...Data.Prismic.getNewsPost().data.image.proxy,
-                          url: 'test.jpg'
-                        }
+              comp.news$ = of({
+                post: {
+                  ...Data.Prismic.getNewsPost(),
+                  data: {
+                    ...Data.Prismic.getNewsPost().data,
+                    image: {
+                      ...Data.Prismic.getNewsPost().data.image,
+                      proxy: {
+                        ...Data.Prismic.getNewsPost().data.image.proxy,
+                        url: 'test.jpg'
                       }
                     }
-                  } as any
-                })
-              );
-              activatedRoute.testParamMap = { uid: 'uid' };
+                  }
+                } as any
+              });
               fixture.detectChanges();
             });
 
@@ -231,24 +222,21 @@ describe('NewsPostComponent', () => {
 
           describe('no `image.proxy.url`', () => {
             beforeEach(() => {
-              (prismicService.getPost as jest.Mock).mockReturnValue(
-                of({
-                  post: {
-                    ...Data.Prismic.getNewsPost(),
-                    data: {
-                      ...Data.Prismic.getNewsPost().data,
-                      image: {
-                        ...Data.Prismic.getNewsPost().data.image,
-                        proxy: {
-                          ...Data.Prismic.getNewsPost().data.image.proxy,
-                          url: undefined
-                        }
+              comp.news$ = of({
+                post: {
+                  ...Data.Prismic.getNewsPost(),
+                  data: {
+                    ...Data.Prismic.getNewsPost().data,
+                    image: {
+                      ...Data.Prismic.getNewsPost().data.image,
+                      proxy: {
+                        ...Data.Prismic.getNewsPost().data.image.proxy,
+                        url: undefined
                       }
                     }
-                  } as any
-                })
-              );
-              activatedRoute.testParamMap = { uid: 'uid' };
+                  }
+                } as any
+              });
               fixture.detectChanges();
             });
 
@@ -262,10 +250,9 @@ describe('NewsPostComponent', () => {
       describe('Content', () => {
         describe('Text', () => {
           beforeEach(() => {
-            (prismicService.getPost as jest.Mock).mockReturnValue(
-              of({ post: Data.Prismic.getNewsPosts('post-2') })
-            );
-            activatedRoute.testParamMap = { uid: 'uid' };
+            comp.news$ = of({
+              post: Data.Prismic.getNewsPosts('post-2')
+            });
             fixture.detectChanges();
           });
 
@@ -290,10 +277,9 @@ describe('NewsPostComponent', () => {
 
         describe('Image', () => {
           beforeEach(() => {
-            (prismicService.getPost as jest.Mock).mockReturnValue(
-              of({ post: Data.Prismic.getNewsPosts('post-3') })
-            );
-            activatedRoute.testParamMap = { uid: 'uid' };
+            comp.news$ = of({
+              post: Data.Prismic.getNewsPosts('post-3')
+            });
             fixture.detectChanges();
           });
 
@@ -317,10 +303,9 @@ describe('NewsPostComponent', () => {
 
         describe('Duo', () => {
           beforeEach(() => {
-            (prismicService.getPost as jest.Mock).mockReturnValue(
-              of({ post: Data.Prismic.getNewsPosts('post-4') })
-            );
-            activatedRoute.testParamMap = { uid: 'uid' };
+            comp.news$ = of({
+              post: Data.Prismic.getNewsPosts('post-4')
+            });
             fixture.detectChanges();
           });
 
@@ -344,10 +329,9 @@ describe('NewsPostComponent', () => {
 
         describe('Gallery', () => {
           beforeEach(() => {
-            (prismicService.getPost as jest.Mock).mockReturnValue(
-              of({ post: Data.Prismic.getNewsPosts('post-5') })
-            );
-            activatedRoute.testParamMap = { uid: 'uid' };
+            comp.news$ = of({
+              post: Data.Prismic.getNewsPosts('post-5')
+            });
             fixture.detectChanges();
           });
 
@@ -371,10 +355,9 @@ describe('NewsPostComponent', () => {
 
         describe('Video', () => {
           beforeEach(() => {
-            (prismicService.getPost as jest.Mock).mockReturnValue(
-              of({ post: Data.Prismic.getNewsPosts('post-6') })
-            );
-            activatedRoute.testParamMap = { uid: 'uid' };
+            comp.news$ = of({
+              post: Data.Prismic.getNewsPosts('post-6')
+            });
             fixture.detectChanges();
           });
 

--- a/packages/angular/src/app/pages/news/news-post/news-post.component.ts
+++ b/packages/angular/src/app/pages/news/news-post/news-post.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { ActivatedRoute, ParamMap } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
 import { Observable } from 'rxjs';
-import { switchMap, map, filter } from 'rxjs/operators';
 
 import { PrismicService, PostReturn } from 'shared';
 
@@ -21,10 +20,9 @@ export class NewsPostComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.news$ = this.route.paramMap.pipe(
-      map((params: ParamMap) => params.get('uid')),
-      filter((uid): uid is string => Boolean(uid)),
-      switchMap(uid => this.prismicService.getPost('news', uid))
-    );
+    const uid = this.route.snapshot.paramMap.get('uid');
+    if (!uid) throw new Error('No `uid`');
+
+    this.news$ = this.prismicService.getPost('news', uid);
   }
 }

--- a/packages/angular/src/app/shared/api.service.ts
+++ b/packages/angular/src/app/shared/api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { tap, map } from 'rxjs/operators';
 
 import { environment } from 'environment';
@@ -14,7 +14,8 @@ import {
   SERVICES,
   CASE_STUDIES,
   getPostUrl,
-  createPostMetaTags
+  createPostMetaTags,
+  isKnownPostType
 } from './api.helpers';
 
 const TEAM = `${environment.api.url}team.json`;
@@ -52,10 +53,12 @@ export class ApiService {
     );
   }
 
-  getPost<T extends PostType>(
+  getPost<T extends PostType | string>(
     type: T,
     id: string
   ): Observable<getPost<T> | null> {
+    if (!isKnownPostType(type)) return of(null);
+
     const url = getPostUrl(type);
 
     return this.http.get<Array<getPost<T>>>(url).pipe(

--- a/packages/angular/src/app/shared/post/post.component.ts
+++ b/packages/angular/src/app/shared/post/post.component.ts
@@ -6,13 +6,12 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef
 } from '@angular/core';
-import { ActivatedRoute, ParamMap } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
-import { Subscription, of } from 'rxjs';
-import { switchMap, map, filter } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
 
-import { ApiService, Post } from 'shared';
-import { isCaseStudy, isKnownPostType } from 'shared/api.helpers';
+import { ApiService, Post, PostType } from 'shared';
+import { isCaseStudy } from 'shared/api.helpers';
 import { CaseStudy } from 'api';
 
 @Component({
@@ -43,22 +42,12 @@ export class PostComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.post$ = this.route.paramMap
-      .pipe(
-        map((params: ParamMap) => ({
-          type: params.get('type'),
-          id: params.get('id')
-        })),
-        filter(
-          (res): res is { type: string; id: string } =>
-            res.type !== null && res.id !== null
-        ),
-        switchMap(({ type, id }) => {
-          if (!isKnownPostType(type)) return of(null);
+    const type = this.route.snapshot.paramMap.get('type');
+    const id = this.route.snapshot.paramMap.get('id');
+    if (!type || !id) throw new Error('No param');
 
-          return this.apiService.getPost(type, id);
-        })
-      )
+    this.post$ = this.apiService
+      .getPost(type as PostType, id)
       .subscribe(post => {
         this.post = post;
         this.changeDetectorRef.markForCheck();


### PR DESCRIPTION
Previously `CareerComponent`, `NewsPostComponent`, and `PostComponent` subscribed to the route `paramMap`, using a `switchMap` to fetch the latest post when route params changed. This meant that if a user routed to the same component, angular would re-use the component instead of destroying it and creating another. However, currently there is no way to route to the same component, and so this commit replaces this and instead gets the initial params only