### PR TITLE
fix(angular): allow images from prismic subdomain

### DIFF
--- a/packages/angular/server.ts
+++ b/packages/angular/server.ts
@@ -45,7 +45,7 @@ app.use(
       imgSrc: [
         `'self'`,
         'https://res.cloudinary.com',
-        'https://hkfd.cdn.prismic.io',
+        'https://*.prismic.io',
         'https://www.google-analytics.com',
         'https://www.google.com',
         'https://www.google.co.uk',


### PR DESCRIPTION
Prismic have changed the subdomain they serve images from, so this commit ammends the CSP to allow images from the new subdomain